### PR TITLE
feat: reduce .nlp files size

### DIFF
--- a/lib/nlp/nlp-manager.js
+++ b/lib/nlp/nlp-manager.js
@@ -471,7 +471,9 @@ class NlpManager {
           // Create a array filled with as many zeros as features
           const features = Array(classifier.features.length).fill(0);
           // Set the features for the positions stored with 1. The others remains as zero.
-          row.forEach(featPosition => features.splice(featPosition, 0, 1));
+          row.forEach((featPosition) => {
+            features[featPosition] = 1;
+          });
           lrc.observations[label][rowIndex] = features;
         });
       });

--- a/lib/nlp/nlp-manager.js
+++ b/lib/nlp/nlp-manager.js
@@ -351,14 +351,20 @@ class NlpManager {
       const optionalUtterance = this.nerManager.generateEntityUtterance(utterance, truncated);
       if (optionalUtterance !== utterance) {
         const optionalClassification = this.classify(truncated, optionalUtterance);
-        if (optionalClassification && optionalClassification.length > 0
-          && optionalClassification[0].value > result.classification[0].value) {
+        if (
+          optionalClassification &&
+          optionalClassification.length > 0 &&
+          optionalClassification[0].value > result.classification[0].value
+        ) {
           result.classification = optionalClassification;
         }
       }
     }
-    if (!result.classification || result.classification.length === 0 ||
-      this.isEqualClassification(result.classification)) {
+    if (
+      !result.classification ||
+      result.classification.length === 0 ||
+      this.isEqualClassification(result.classification)
+    ) {
       result.intent = 'None';
       result.score = 1;
     } else {
@@ -414,7 +420,17 @@ class NlpManager {
         classifierClone.logistic = {};
         const { logistic } = classifierClone;
         const lrc = classifier.settings.classifier;
+
         logistic.observations = lrc.observations;
+        Object.entries(lrc.observations).forEach(([label, matrix]) => {
+          matrix.forEach((features, row) => {
+            //  Store array of positions for the features equals to 1.
+            logistic.observations[label][row] = features
+              .map((feat, index) => (feat === 1 ? index : undefined))
+              .filter(n => n);
+          });
+        });
+
         logistic.labels = lrc.labels;
         logistic.classifications = lrc.classifications;
         logistic.observationCount = lrc.observationCount;
@@ -447,7 +463,19 @@ class NlpManager {
       classifier.features = classifierClone.features;
       const lrc = classifier.settings.classifier;
       const { logistic } = classifierClone;
-      lrc.observations = logistic.observations;
+
+      lrc.observations = {};
+      Object.entries(logistic.observations).forEach(([label, matrix]) => {
+        lrc.observations[label] = [];
+        matrix.forEach((row, rowIndex) => {
+          // Create a array filled with as many zeros as features
+          const features = Array(classifier.features.length).fill(0);
+          // Set the features for the positions stored with 1. The others remains as zero.
+          row.forEach(featPosition => features.splice(featPosition, 0, 1));
+          lrc.observations[label][rowIndex] = features;
+        });
+      });
+
       lrc.labels = logistic.labels;
       lrc.classifications = logistic.classifications;
       lrc.observationCount = logistic.observationCount;


### PR DESCRIPTION
## PR Checklist

- [x] I have run `npm test` locally and all tests are passing.
- [N/A] I have added/updated tests for any new behavior.
- [x] If this is a significant change, an issue has already been created where the problem / solution was discussed: #11 

## PR Description

#### 🔧 store labels/features matrix rows in a simple way

Before,  the rows were composed by zeros and ones. To reduce the size of the resulting .npl file, now the rows are an array with the positions of the elements equals to one.

```js
// See this example
[0, 0, 1, 0 , 0, 1, 1, 1, 0, 0] => [2, 5, 6, 7]
```

The load function has been adapted to be able to process the new format into the zeros and ones format that the nlp manager needs.