### PR TITLE
feat: Add skip results at Trim Named Entities conditions

### DIFF
--- a/lib/ner/trim-named-entity.js
+++ b/lib/ner/trim-named-entity.js
@@ -82,7 +82,6 @@ class TrimNamedEntity extends NamedEntity {
     });
   }
 
-
   addAfterCondition(srcLanguages, srcWords, srcOptions) {
     this.addPositionCondition('after', srcLanguages, srcWords, srcOptions);
   }
@@ -107,6 +106,22 @@ class TrimNamedEntity extends NamedEntity {
     this.addPositionCondition('beforeLast', srcLanguages, srcWords, srcOptions);
   }
 
+  mustSkip(word, condition) {
+    if (condition.options && condition.options.skip && condition.options.skip.length > 0) {
+      for (let i = 0; i < condition.options.skip.length; i += 1) {
+        const skipWord = condition.options.skip[i];
+        if (condition.options.caseSensitive) {
+          if (skipWord === word) {
+            return true;
+          }
+        } else if (skipWord.toLowerCase() === word.toLowerCase()) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
   matchBetween(utterance, condition) {
     const result = [];
     let matchFound;
@@ -127,7 +142,13 @@ class TrimNamedEntity extends NamedEntity {
         matchFound = false;
       }
     } while (matchFound);
-    return result;
+    const filteredResult = [];
+    for (let i = 0; i < result.length; i += 1) {
+      if (!this.mustSkip(result[i].utteranceText, condition)) {
+        filteredResult.push(result[i]);
+      }
+    }
+    return filteredResult;
   }
 
   findWord(utterance, word, caseSensitive = false, noSpaces = false) {
@@ -280,7 +301,13 @@ class TrimNamedEntity extends NamedEntity {
         result.push(...this.getResults(utterance, wordPositions, condition.type));
       }
     }
-    return result;
+    const filteredResult = [];
+    for (let i = 0; i < result.length; i += 1) {
+      if (!this.mustSkip(result[i].utteranceText, condition)) {
+        filteredResult.push(result[i]);
+      }
+    }
+    return filteredResult;
   }
 
   extract(utterance, language) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2527,7 +2527,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2942,7 +2943,8 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2998,6 +3000,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3041,12 +3044,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/test/ner/ner-manager.test.js
+++ b/test/ner/ner-manager.test.js
@@ -314,5 +314,35 @@ describe('NER Manager', () => {
         utteranceText: 'Madrid',
       });
     });
+    test('A skip word list can be provided', async () => {
+      const manager = new NerManager();
+      const fromEntity = manager.addNamedEntity('fromLocation', 'trim');
+      fromEntity.addBetweenCondition('en', 'from', 'to');
+      fromEntity.addAfterLastCondition('en', 'from');
+      const toEntity = manager.addNamedEntity('toLocation', 'trim');
+      toEntity.addBetweenCondition('en', 'to', 'from', { skip: ['travel'] });
+      toEntity.addAfterLastCondition('en', 'to');
+      const entities = await manager.findEntities('I want to travel from Barcelona to Madrid', 'en');
+      expect(entities).toBeDefined();
+      expect(entities).toHaveLength(2);
+      expect(entities[0]).toEqual({
+        accuracy: 1,
+        end: 31,
+        entity: 'fromLocation',
+        sourceText: 'Barcelona',
+        start: 22,
+        type: 'between',
+        utteranceText: 'Barcelona',
+      });
+      expect(entities[1]).toEqual({
+        accuracy: 0.99,
+        end: 41,
+        entity: 'toLocation',
+        sourceText: 'Madrid',
+        start: 35,
+        type: 'afterLast',
+        utteranceText: 'Madrid',
+      });
+    });
   });
 });


### PR DESCRIPTION
# Pull Request Template

## PR Checklist

- [X] I have run `npm test` locally and all tests are passing.
- [X] I have added/updated tests for any new behavior.
- [X] If this is a significant change, an issue has already been created where the problem / solution was discussed: [N/A, or add link to issue here]

## PR Description

It adds an skip property to the options of the conditions at Trim Named Entities. That way, some results are blacklisted. 
Reason to have that: In the utterance "I want to travel from Madrid to Barcelona", if you want to extract a from location and a to location that works also for "I want to travel to Barcelona from Madrid", you can add:
From: between from and to or last after from
To: between to and from or last after to
The problem is that the "to" condition extract also the "travel" word because is between a "to" and a "from". Skipping "travel" in the between condition works, and the result is the expected.