### PR TITLE
feat: Ability to import / export models as JSON strings

### DIFF
--- a/lib/nlp/nlp-manager.js
+++ b/lib/nlp/nlp-manager.js
@@ -442,11 +442,54 @@ class NlpManager {
   }
 
   /**
-   * Save the NLP manager information into a file.
-   * @param {String} srcFileName Filename for saving the NLP manager.
+   * Load NLP manager information from a string.
+   * @param {String} data JSON string to load NLP manager information from.
    */
-  save(srcFileName) {
-    const fileName = srcFileName || 'model.nlp';
+  import(data) {
+    const clone = JSON.parse(data);
+
+    this.settings = clone.settings;
+    this.languages = clone.languages;
+    this.nerManager.load(clone.nerManager);
+    this.intentEntities = clone.intentEntities;
+    this.intentDomains = clone.intentDomains || {};
+    this.nlgManager.responses = clone.responses;
+    for (let i = 0, l = clone.classifiers.length; i < l; i += 1) {
+      const classifierClone = clone.classifiers[i];
+      this.addLanguage(classifierClone.language);
+      const classifier = this.classifiers[classifierClone.language];
+
+      classifier.docs = classifierClone.docs;
+      classifier.features = classifierClone.features;
+      const lrc = classifier.settings.classifier;
+      const { logistic } = classifierClone;
+
+      lrc.observations = {};
+      Object.entries(logistic.observations).forEach(([label, matrix]) => {
+        lrc.observations[label] = [];
+        matrix.forEach((row, rowIndex) => {
+          // Create a array filled with as many zeros as features
+          const features = Array(classifier.features.length).fill(0);
+          // Set the features for the positions stored with 1. The others remains as zero.
+          row.forEach((featPosition) => {
+            features[featPosition] = 1;
+          });
+          lrc.observations[label][rowIndex] = features;
+        });
+      });
+
+      lrc.labels = logistic.labels;
+      lrc.classifications = logistic.classifications;
+      lrc.observationCount = logistic.observationCount;
+      lrc.theta = logistic.theta;
+    }
+  }
+
+  /**
+   * Export NLP manager information as a string.
+   * @returns {String} NLP manager information as a JSON string.
+   */
+  export(minified = false) {
     const clone = {};
     clone.settings = this.settings;
     clone.languages = this.languages;
@@ -483,7 +526,17 @@ class NlpManager {
         clone.classifiers.push(classifierClone);
       });
     }
-    fs.writeFileSync(fileName, JSON.stringify(clone, null, 2), 'utf8');
+
+    return minified ? JSON.stringify(clone) : JSON.stringify(clone, null, 2);
+  }
+
+  /**
+   * Save the NLP manager information into a file.
+   * @param {String} srcFileName Filename for saving the NLP manager.
+   */
+  save(srcFileName) {
+    const fileName = srcFileName || 'model.nlp';
+    fs.writeFileSync(fileName, this.export(), 'utf8');
   }
 
   /**
@@ -493,42 +546,7 @@ class NlpManager {
   load(srcFileName) {
     const fileName = srcFileName || 'model.nlp';
     const data = fs.readFileSync(fileName, 'utf8');
-    const clone = JSON.parse(data);
-    this.settings = clone.settings;
-    this.languages = clone.languages;
-    this.nerManager.load(clone.nerManager);
-    this.intentEntities = clone.intentEntities;
-    this.intentDomains = clone.intentDomains || {};
-    this.nlgManager.responses = clone.responses;
-    for (let i = 0, l = clone.classifiers.length; i < l; i += 1) {
-      const classifierClone = clone.classifiers[i];
-      this.addLanguage(classifierClone.language);
-      const classifier = this.classifiers[classifierClone.language];
-
-      classifier.docs = classifierClone.docs;
-      classifier.features = classifierClone.features;
-      const lrc = classifier.settings.classifier;
-      const { logistic } = classifierClone;
-
-      lrc.observations = {};
-      Object.entries(logistic.observations).forEach(([label, matrix]) => {
-        lrc.observations[label] = [];
-        matrix.forEach((row, rowIndex) => {
-          // Create a array filled with as many zeros as features
-          const features = Array(classifier.features.length).fill(0);
-          // Set the features for the positions stored with 1. The others remains as zero.
-          row.forEach((featPosition) => {
-            features[featPosition] = 1;
-          });
-          lrc.observations[label][rowIndex] = features;
-        });
-      });
-
-      lrc.labels = logistic.labels;
-      lrc.classifications = logistic.classifications;
-      lrc.observationCount = logistic.observationCount;
-      lrc.theta = logistic.theta;
-    }
+    this.import(data);
   }
 
   loadExcel(srcFileName) {


### PR DESCRIPTION
# Pull Request Template

## PR Checklist

- [x] I have run `npm test` locally and all tests are passing.
- [x] I have added/updated tests for any new behavior.
- [x] If this is a significant change, an issue has already been created where the problem / solution was discussed: [See Issue](https://github.com/axa-group/nlp.js/issues/34)

## PR Description

Closes https://github.com/axa-group/nlp.js/issues/34

This PR adds the ability to import and export models as JSON strings using `NlpManager.import()` and `NlpManager.export()` respectively. Note that this does not break any previous `.load()` or `.save()` functionality.

### Implementation Details

The code for importing/exporting models from a JSON string had already existed in the `.save()` and `.load()` methods. 

This PR abstracts some of the functionality into standalone `import()` and `export()` methods that focus exclusively on parsing or serializing JSON strings. 

This is useful for use cases where the models are not necessarily hosted in a file (i.e. a database or from memory) [More Details on Issue #34](https://github.com/axa-group/nlp.js/issues/34)