### PR TITLE
feat: Add entity extraction method to NLP manager

### DIFF
--- a/lib/nlp/nlp-manager.js
+++ b/lib/nlp/nlp-manager.js
@@ -333,6 +333,32 @@ class NlpManager {
   }
 
   /**
+   * Process to extract entities from an utterance.
+   * @param {string} srcLocale Locale of the utterance, optional.
+   * @param {string} srcUtterance Text of the utterance.
+   * @param {string[]} whitelist Optional whitelist of entity names.
+   * @returns {Object[]} Array of entities.
+   */
+  async extractEntities(srcLocale, srcUtterance, whitelist) {
+    let utterance = srcUtterance;
+    let locale = srcLocale;
+    if (!utterance) {
+      utterance = locale;
+      locale = this.guessLanguage(utterance);
+    }
+    if (!this.languages.includes(NlpUtil.getTruncatedLocale(locale))) {
+      locale = this.guessLanguage(utterance);
+    }
+    const truncated = NlpUtil.getTruncatedLocale(locale);
+    const result = await this.nerManager.findEntities(
+      utterance,
+      truncated,
+      whitelist,
+    );
+    return result;
+  }
+
+  /**
    * Process an utterance for full classify and analyze. If the locale is
    * not provided, then it will be guessed.
    * Classify the utterance and extract entities from it, returning an

--- a/test/nlp/nlp-manager.test.js
+++ b/test/nlp/nlp-manager.test.js
@@ -321,6 +321,60 @@ describe('NLP Manager', () => {
     });
   });
 
+  describe('Extract Entities', () => {
+    test('Should search for entities', async () => {
+      const manager = new NlpManager({ ner: { builtins: [] } });
+      manager.addLanguage(['en']);
+      manager.addNamedEntityText('hero', 'spiderman', ['en'], ['Spiderman', 'Spider-man']);
+      manager.addNamedEntityText('hero', 'iron man', ['en'], ['iron man', 'iron-man']);
+      manager.addNamedEntityText('hero', 'thor', ['en'], ['Thor']);
+      manager.addNamedEntityText('food', 'burguer', ['en'], ['Burguer', 'Hamburguer']);
+      manager.addNamedEntityText('food', 'pizza', ['en'], ['pizza']);
+      manager.addNamedEntityText('food', 'pasta', ['en'], ['Pasta', 'spaghetti']);
+      manager.addDocument('en', 'I saw %hero% eating %food%', 'sawhero');
+      manager.addDocument('en', 'I have seen %hero%, he was eating %food%', 'sawhero');
+      manager.addDocument('en', 'I want to eat %food%', 'wanteat');
+      const result = await manager.extractEntities('I saw spiderman eating spaghetti today in the city!');
+      expect(result).toHaveLength(2);
+      expect(result[0].sourceText).toEqual('Spiderman');
+      expect(result[1].sourceText).toEqual('spaghetti');
+    });
+    test('Should search for entities if the language is specified', async () => {
+      const manager = new NlpManager({ ner: { builtins: [] } });
+      manager.addLanguage(['en']);
+      manager.addNamedEntityText('hero', 'spiderman', ['en'], ['Spiderman', 'Spider-man']);
+      manager.addNamedEntityText('hero', 'iron man', ['en'], ['iron man', 'iron-man']);
+      manager.addNamedEntityText('hero', 'thor', ['en'], ['Thor']);
+      manager.addNamedEntityText('food', 'burguer', ['en'], ['Burguer', 'Hamburguer']);
+      manager.addNamedEntityText('food', 'pizza', ['en'], ['pizza']);
+      manager.addNamedEntityText('food', 'pasta', ['en'], ['Pasta', 'spaghetti']);
+      manager.addDocument('en', 'I saw %hero% eating %food%', 'sawhero');
+      manager.addDocument('en', 'I have seen %hero%, he was eating %food%', 'sawhero');
+      manager.addDocument('en', 'I want to eat %food%', 'wanteat');
+      const result = await manager.extractEntities('en', 'I saw spiderman eating spaghetti today in the city!');
+      expect(result).toHaveLength(2);
+      expect(result[0].sourceText).toEqual('Spiderman');
+      expect(result[1].sourceText).toEqual('spaghetti');
+    });
+    test('If the locale is not one of the nlp manager, then guess language', async () => {
+      const manager = new NlpManager({ ner: { builtins: [] } });
+      manager.addLanguage(['en']);
+      manager.addNamedEntityText('hero', 'spiderman', ['en'], ['Spiderman', 'Spider-man']);
+      manager.addNamedEntityText('hero', 'iron man', ['en'], ['iron man', 'iron-man']);
+      manager.addNamedEntityText('hero', 'thor', ['en'], ['Thor']);
+      manager.addNamedEntityText('food', 'burguer', ['en'], ['Burguer', 'Hamburguer']);
+      manager.addNamedEntityText('food', 'pizza', ['en'], ['pizza']);
+      manager.addNamedEntityText('food', 'pasta', ['en'], ['Pasta', 'spaghetti']);
+      manager.addDocument('en', 'I saw %hero% eating %food%', 'sawhero');
+      manager.addDocument('en', 'I have seen %hero%, he was eating %food%', 'sawhero');
+      manager.addDocument('en', 'I want to eat %food%', 'wanteat');
+      const result = await manager.extractEntities('es', 'I saw spiderman eating spaghetti today in the city!');
+      expect(result).toHaveLength(2);
+      expect(result[0].sourceText).toEqual('Spiderman');
+      expect(result[1].sourceText).toEqual('spaghetti');
+    });
+  });
+
   describe('Process', () => {
     test('Should classify an utterance', async () => {
       const manager = new NlpManager();


### PR DESCRIPTION
# Pull Request Template

## PR Checklist

- [X] I have run `npm test` locally and all tests are passing.
- [X] I have added/updated tests for any new behavior.
- [X] If this is a significant change, an issue has already been created where the problem / solution was discussed: [N/A, or add link to issue here]

## PR Description

Add entity extraction method to NLP manager, so entites can be extracted without all the process of sentiment analysis and intent recognition.