### PR TITLE
fix: fix missing await in NLU-Benchmark

### DIFF
--- a/examples/nlu-benchmark/index.js
+++ b/examples/nlu-benchmark/index.js
@@ -14,7 +14,7 @@ async function scoreCorpus(corpus) {
       manager.addDocument('en', sentence.text, sentence.intent);
     }
   }
-  manager.train();
+  await manager.train();
   let total = 0;
   let correct = 0;
   for (let i = 0; i < sentences.length; i += 1) {


### PR DESCRIPTION
## PR Checklist

- [x] I have run `npm test` locally and all tests are passing.
- [x] I have added/updated tests for any new behavior.
- [x] If this is a significant change, an issue has already been created where the problem / solution was discussed: https://github.com/axa-group/nlp.js/issues/81 

## PR Description

Adds await to `manager.train()` so the process starts after training ends. This was impacting
benchmarking scores

closes #81