### PR TITLE
:bug: fix: language detection not working for some languages

### DIFF
--- a/lib/language/languages.json
+++ b/lib/language/languages.json
@@ -26,7 +26,7 @@
   },
   {
     "alpha2": "ar",
-    "alpha3": "ara",
+    "alpha3": "arb",
     "name": "Arabic"
   },
   {
@@ -911,7 +911,7 @@
   },
   {
     "alpha2": "zh",
-    "alpha3": "zho",
+    "alpha3": "cmn",
     "name": "Chinese"
   },
   {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "prettier": "^1.14.3"
   },
   "dependencies": {
-    "@microsoft/recognizers-text-suite": "^1.1.3",
+    "@microsoft/recognizers-text-suite": "1.1.3",
     "brain.js": "^1.4.2",
     "escodegen": "^1.10.0",
     "esprima": "^4.0.0",


### PR DESCRIPTION
Resolves #99

## PR Checklist

- [x] I have run `npm test` locally and all tests are passing.
- [ ] I have added/updated tests for any new behavior.
- [x] If this is a significant change, an issue has already been created where the problem / solution was discussed: [N/A, or add link to issue here]

## PR Description

Some languages are not working with language detection that should. The problem seems to be [`franc`](https://github.com/wooorm/franc) is using one set of language codes and this package is using another.

**Note:** I didn't go through all the languages; I only checked the top ~30.