### PR TITLE
Fix .npmignore file

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -2,6 +2,5 @@ screenshots
 model.nlp
 docs
 examples
-docs/static
 .github
 .vscode

--- a/.npmignore
+++ b/.npmignore
@@ -4,7 +4,5 @@ docs
 examples
 docs/static
 test
-coverage
 .github
-dist
 .vscode

--- a/.npmignore
+++ b/.npmignore
@@ -7,3 +7,4 @@ test
 coverage
 .github
 dist
+.vscode

--- a/.npmignore
+++ b/.npmignore
@@ -1,5 +1,9 @@
-./screenshots
-./model.nlp
-./docs
-./examples
-./docs/static
+screenshots
+model.nlp
+docs
+examples
+docs/static
+test
+coverage
+.github
+dist

--- a/.npmignore
+++ b/.npmignore
@@ -3,6 +3,5 @@ model.nlp
 docs
 examples
 docs/static
-test
 .github
 .vscode


### PR DESCRIPTION
## PR Description

Hi,

First, thank you for this awesome library! 

I installed it locally using NPM and realized that the module was taking **60Mb** on my disk. 

By looking at the folder structure, it seems that many folders (screenshots, documentation, .vscode, .github) are uploaded to NPM.

Here is the folder structure of the module uploaded to NPM:

<img width="314" alt="screenshot 2019-02-05 at 09 12 57" src="https://user-images.githubusercontent.com/7365207/52249553-57cc1780-2926-11e9-88c7-3e8b10c286b4.png">

So I checked the .npmignore, and indeed it was not working properly.

Here is a proposal of a fix in this PR.

Note: 

- I added the `coverage`, `test`, `.github` and `.vscode` folder. I don't think there are relevant when running the library.
- I added the `dist` folder to the .npmignore too, because it's a duplicate of the code and it seems that the package.json is calling `lib/index.js` as the main file, not the bundle one. Tell me if you think it's ok. 

## PR Checklist

This is a minor change not affecting tests :)