### PR TITLE
docs(ner-manager): change default threshold to 0.8

### DIFF
--- a/docs/ner-manager.md
+++ b/docs/ner-manager.md
@@ -2,7 +2,7 @@
 
 The Named Entity Recognition manager is able to store an structure of entities and options of the entity for each language.
 Then, given an utterance and the language, is able to search the options of the entity inside the utterance, and return a list
-of the bests substrings. This is done using a threshold for the accuracy, by default the accuracy is 0.5 but you can provide it in the options when creating the instance.
+of the bests substrings. This is done using a threshold for the accuracy, by default the accuracy is 0.8 but you can provide it in the options when creating the instance.
 
 ## Enum Named Entities
 


### PR DESCRIPTION
# Pull Request Template

## PR Checklist

- [ ] I have run `npm test` locally and all tests are passing.
- [ ] I have added/updated tests for any new behavior.
- [ ] If this is a significant change, an issue has already been created where the problem / solution was discussed: [N/A, or add link to issue here]

## PR Description

It seems the default threshold value has changed since the NER manager documentation has been written. The current default value is now `0.8` (cf. [lib/ner/ner-manager.js#L52](https://github.com/axa-group/nlp.js/blob/master/lib/ner/ner-manager.js#L52)).