### PR TITLE
Fix Chinese Entity Extraction

### DIFF
--- a/lib/nlg/nlg-manager.js
+++ b/lib/nlg/nlg-manager.js
@@ -24,7 +24,7 @@
 const Evaluator = require('../util/evaluator');
 
 /**
- * Natural Language Generator Manger
+ * Natural Language Generator Manager
  */
 class NlgManager {
   /**

--- a/lib/util/similar-search.js
+++ b/lib/util/similar-search.js
@@ -21,6 +21,8 @@
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
+const { Language } = require('../language');
+
 /**
  * Class for checking similarity between strings, or search the more similar
  * substring inside an string.
@@ -133,6 +135,10 @@ class SimilarSearch {
    *                     end index, and length.
    */
   getWordPositions(str) {
+    const scripts = [];
+    for (let i = 0; i < str.length; i += 1) {
+      scripts.push(Language.getTopScript(str.substr(i, 1)));
+    }
     const strlen = str.length;
     const result = [];
     let lastIndex = 0;
@@ -149,8 +155,18 @@ class SimilarSearch {
           atWhiteSpace = true;
         }
       } else if (atWhiteSpace) {
-        lastIndex = currentIndex;
-        atWhiteSpace = false;
+        if (scripts[currentIndex][0] === 'cmn') {
+          result.push({
+            start: currentIndex,
+            end: currentIndex,
+            len: 1,
+          });
+          lastIndex = currentIndex;
+          atWhiteSpace = true;
+        } else {
+          lastIndex = currentIndex;
+          atWhiteSpace = false;
+        }
       }
       currentIndex += 1;
     }

--- a/test/ner/ner-manager.test.js
+++ b/test/ner/ner-manager.test.js
@@ -257,6 +257,21 @@ describe('NER Manager', () => {
       expect(entities[0].entity).toEqual('hero');
       expect(entities[0].utteranceText).toEqual('spiderman');
     });
+    test('Should find chinese entities', async () => {
+      const manager = new NerManager();
+      manager.addNamedEntityText('place', '餐廳', ['zh'], ['餐廳']);
+      const entities = await manager.findEntities('找餐廳', 'zh');
+      expect(entities).toBeDefined();
+      expect(entities).toHaveLength(1);
+      expect(entities[0].start).toEqual(1);
+      expect(entities[0].end).toEqual(2);
+      expect(entities[0].levenshtein).toEqual(0);
+      expect(entities[0].accuracy).toEqual(1);
+      expect(entities[0].option).toEqual('餐廳');
+      expect(entities[0].sourceText).toEqual('餐廳');
+      expect(entities[0].entity).toEqual('place');
+      expect(entities[0].utteranceText).toEqual('餐廳');
+    });
     test('Should find an entity if levenshtein greater than threshold', async () => {
       const manager = new NerManager({ threshold: 0.8 });
       manager.addNamedEntityText(


### PR DESCRIPTION
# Pull Request Template

## PR Checklist

- [x] I have run `npm test` locally and all tests are passing.
- [x] I have added/updated tests for any new behavior.
- [x] If this is a significant change, an issue has already been created where the problem / solution was discussed: [N/A, or add link to issue here]

## PR Description

Chinese entity extraction was not working properly due to the fact that the language does not contains whitespaces. Now, when getting words positions, first the top script (latin, cmn, ...) of each character is extracted, and if the character is cmn (chinese charset) then the character is considered a full word.