### PR TITLE
Fix ner-manager.generateEntityUtterance

### DIFF
--- a/lib/ner/ner-manager.js
+++ b/lib/ner/ner-manager.js
@@ -530,12 +530,13 @@ class NerManager {
     if (entities.length === 0) {
       return utterance;
     }
+    entities.sort((a, b) => a.start - b.start);
     let index = 0;
     let result = '';
     for (let i = 0; i < entities.length; i += 1) {
       const entity = entities[i];
       const left = utterance.slice(index, entity.start);
-      index = entity.end;
+      index = entity.end + 1;
       result += left;
       result += `%${entity.entity}%`;
     }

--- a/test/ner/ner-manager.test.js
+++ b/test/ner/ner-manager.test.js
@@ -538,4 +538,24 @@ describe('NER Manager', () => {
       });
     });
   });
+
+  describe('Generate entity utterance', () => {
+    test('Should replace entities by they names', async () => {
+      const manager = new NerManager();
+      manager.addNamedEntityText('hero', 'ironman', ['en'], ['ironman']);
+      manager.addNamedEntityText('hero', 'thor', ['en'], ['Thor']);
+      manager.addNamedEntityText('food', 'pizza', ['en'], ['pizza']);
+      const utterance = 'I saw thor and ironman, they where eating pizza';
+      const result = await manager.generateEntityUtterance(utterance, 'en');
+      expect(result).toEqual(
+        'I saw %hero% and %hero%, they where eating %food%'
+      );
+    });
+    test('Should replace nothing if no entities', async () => {
+      const manager = new NerManager();
+      const utterance = 'I saw thor and ironman, they where eating pizza';
+      const result = await manager.generateEntityUtterance(utterance, 'en');
+      expect(result).toEqual('I saw thor and ironman, they where eating pizza');
+    });
+  });
 });


### PR DESCRIPTION
# Pull Request Template

## PR Checklist

- [x] I have run `npm test` locally and all tests are passing.
- [x] I have added/updated tests for any new behavior.
- [ ] If this is a significant change, an issue has already been created where the problem / solution was discussed: [N/A, or add link to issue here]

## PR Description

ner-manager.generateEntityUtterance() was returning wrong utterances.