### PR TITLE
New feature: Numbered entities

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ The version 3 comes with some important changes, mainly focused on improve perfo
   - [Enum Named Entities](docs/ner-manager.md#enum-named-entities)
   - [Regular Expression Named Entities](docs/ner-manager.md#regular-expression-named-entities)
   - [Trim Named Entities](docs/ner-manager.md#trim-named-entities)
+  - [Utterances with duplicated Entities](docs/ner-manager.md#utterances-with-duplicated-entities)
 - [Builtin Entity Extraction](docs/builtin-entity-extraction.md)
   - [Email Extraction](docs/builtin-entity-extraction.md#email-extraction)
   - [IP Extraction](docs/builtin-entity-extraction.md#ip-extraction)

--- a/docs/ner-manager.md
+++ b/docs/ner-manager.md
@@ -152,3 +152,53 @@ manager.findEntities(
 //     utteranceText: 'travel',
 //     entity: 'fromEntity' } ]
 ```
+
+## Utterances with duplicated Entities
+
+Utterances with more than one entity with the same name are supported, providing a "whitelist" with numbered entity names.
+
+The "numbered entity" format must be in the form `${entityName}_${integer}`. E.g. "hero\_1", "food\_2", etc.
+
+```javascript
+const { NerManager } = require('node-nlp');
+
+const manager = new NerManager();
+
+manager.addNamedEntityText('hero', 'spiderman', ['en'], ['Spider-man']);
+manager.addNamedEntityText('hero', 'iron man', ['en'], ['ironman']);
+manager.addNamedEntityText('food', 'pizza', ['en'], ['pizza']);
+manager.addNamedEntityText('food', 'pasta', ['en'], ['spaghetti']);
+
+const entities = manager.findEntities(
+  'I saw spiderman eating spaghetti and ironman eating pizza',
+  'en',
+  ['hero_1', 'hero_2', 'food_1', 'food_2'],
+);
+
+// entities = [
+//   {
+//     entity: "hero_1",
+//     option: "spiderman",
+//     utteranceText: "spiderman",
+//     ...
+//   },
+//   {
+//     entity: "food_1",
+//     option: "pasta",
+//     utteranceText: "spaghetti",
+//     ...
+//   },
+//   {
+//     entity: "hero_2",
+//     option: "iron man",
+//     utteranceText: "ironman",
+//     ...
+//   },
+//   {
+//     entity: "food_2",
+//     option: "pizza",
+//     utteranceText: "pizza",
+//     ...
+//   }
+// ]
+```

--- a/docs/slot-filling.md
+++ b/docs/slot-filling.md
@@ -135,7 +135,7 @@ Utterances with more than one entity with the same name are supported by providi
 The "numbered entity" format must be in the form `${entityName}_${integer}`. E.g. "hero\_1", "food\_2", etc.
 
 ```javascript
-const { NerManager } = require('node-nlp');
+const { NlpManager } = require('node-nlp');
 
 async function main() {
   const manager = new NlpManager({ languages: ['en'] });

--- a/docs/slot-filling.md
+++ b/docs/slot-filling.md
@@ -128,4 +128,62 @@ main();
 // }
 ```
 
+## Entities with the same name
+
+Utterances with more than one entity with the same name are supported by providing "numbered entities".
+
+The "numbered entity" format must be in the form `${entityName}_${integer}`. E.g. "hero\_1", "food\_2", etc.
+
+```javascript
+const { NerManager } = require('node-nlp');
+
+async function main() {
+  const manager = new NlpManager({ languages: ['en'] });
+
+  manager.addDocument(
+    'en',
+    'I saw %hero_1% together with %hero_2%, they where eating %food%',
+    'saw_heroes_eating'
+  );
+
+  await manager.train();
+
+  manager.addNamedEntityText('hero', 'spiderman', ['en'], ['Spider-man']);
+  manager.addNamedEntityText('hero', 'iron man', ['en'], ['iron man']);
+  manager.addNamedEntityText('hero', 'thor', ['en'], ['Thor']);
+  manager.addNamedEntityText('food', 'burguer', ['en'], ['Burguer']);
+  manager.addNamedEntityText('food', 'pizza', ['en'], ['pizza']);
+  manager.addNamedEntityText('food', 'pasta', ['en'], ['Pasta', 'spaghetti']);
+
+  manager.slotManager.addSlot('saw_heroes_eating', 'hero_1', true, { en: 'Who did you see?' });
+  manager.slotManager.addSlot('saw_heroes_eating', 'hero_2', true, { en: 'With whom did you see {{ hero_1 }}?' });
+  manager.slotManager.addSlot('saw_heroes_eating', 'food', true, { en: 'What where they eating?' });
+
+  manager.addAnswer('en', 'saw_heroes_eating', 'Wow! You saw {{ hero_1 }} and {{ hero_2 }} eating {{ food }}!');
+
+  const result1 = await manager.process('I saw spiderman together with ironman, they where eating spaghetti');
+  console.log(result1.answer);
+
+  const result2 = await manager.process('I saw iron-man and the other hero, they where eating a burger');
+  console.log(result2.answer);
+
+  const result3 = await manager.process('I saw him together with thor, they where eating pizza');
+  console.log(result3.answer);
+
+  const result4 = await manager.process('I saw iron-man together with thor, they where eating');
+  console.log(result4.answer);
+
+  const result5 = await manager.process('I saw them together, they where eating');
+  console.log(result5.answer);
+
+  // Console output:
+  // Wow! You saw spiderman and iron man eating pasta!
+  // With whom did you see iron man?
+  // With whom did you see thor?
+  // What where they eating?
+  // Who did you see?
+}
+
+main();
+```
 

--- a/lib/ner/ner-manager.js
+++ b/lib/ner/ner-manager.js
@@ -224,7 +224,9 @@ class NerManager {
    */
   getEntitiesFromUtterance(utterance) {
     const entityKeys = Object.keys(this.namedEntities);
-    return entityKeys.filter(entity => utterance.indexOf(`%${entity}%`) > -1);
+    const regex = new RegExp(`%((${entityKeys.join('|')})(?:_\\d+)?)%`, 'gm');
+    const match = utterance.match(regex);
+    return match ? match.map(item => item.replace(/%/g, '')) : [];
   }
 
   /**
@@ -473,12 +475,29 @@ class NerManager {
    * @param {String} utterance Utterance for searching entities.
    * @param {String} locale Locale of the language.
    * @param {String[]} whitelist Whitelist of entity names.
+   * @param {boolean} includeBuiltin Include built-in entities.
    * @returns {Promise.Object[]} Promise edges of entities found.
    */
-  async findEntities(utterance, language, whitelist) {
-    const entityNames = whitelist || Object.keys(this.namedEntities);
+  findEntities(utterance, language, whitelist, includeBuiltin = true) {
+    let witelistMap;
+
+    if (whitelist) {
+      witelistMap = {};
+      whitelist.forEach(item => {
+        const name = item.replace(/_\d+/g, '');
+        if (!witelistMap[name]) {
+          witelistMap[name] = [];
+        }
+        witelistMap[name].push(item);
+      });
+    }
+
+    const entityNames = Object.keys(witelistMap || this.namedEntities);
     const wordPositions = this.similar.getWordPositions(utterance);
-    const edges = this.findBuiltinEntities(utterance, language);
+    let edges = includeBuiltin
+      ? this.findBuiltinEntities(utterance, language)
+      : [];
+
     entityNames.forEach(entityName => {
       const entity = this.namedEntities[entityName];
       if (entity) {
@@ -489,34 +508,25 @@ class NerManager {
           wordPositions,
           this.threshold
         );
-        newEdges.forEach(edge => {
-          edges.push(edge);
-        });
+        edges = [...edges, ...newEdges];
       }
     });
+
+    edges.sort((a, b) => a.start - b.start);
+
+    if (witelistMap) {
+      edges = edges.map(item => {
+        const edge = item;
+        edge.entity = witelistMap[item.entity].shift() || item.entity;
+        return edge;
+      });
+    }
+
     return this.similar.reduceEdges(this.splitEdges(edges), false);
   }
 
   findNamedEntities(utterance, language, whitelist) {
-    const entityNames = whitelist || Object.keys(this.namedEntities);
-    const wordPositions = this.similar.getWordPositions(utterance);
-    const edges = [];
-    entityNames.forEach(entityName => {
-      const entity = this.namedEntities[entityName];
-      if (entity) {
-        const newEdges = entity.extract(
-          utterance,
-          language,
-          this.similar,
-          wordPositions,
-          this.threshold
-        );
-        newEdges.forEach(edge => {
-          edges.push(edge);
-        });
-      }
-    });
-    return this.similar.reduceEdges(this.splitEdges(edges), false);
+    return this.findEntities(utterance, language, whitelist, false);
   }
 
   /**

--- a/test/ner/ner-manager.test.js
+++ b/test/ner/ner-manager.test.js
@@ -224,6 +224,15 @@ describe('NER Manager', () => {
       );
       expect(entities).toEqual(['entity1', 'entity3']);
     });
+    test('Should find numerated entities inside utterance', () => {
+      const manager = new NerManager();
+      manager.addNamedEntity('hero');
+      manager.addNamedEntity('food');
+      const entities = manager.getEntitiesFromUtterance(
+        'Those are %hero_1% and %hero_3%, with some %food% and %food_6%'
+      );
+      expect(entities).toEqual(['hero_1', 'hero_3', 'food', 'food_6']);
+    });
   });
 
   describe('Find entities', () => {
@@ -436,16 +445,6 @@ describe('NER Manager', () => {
       expect(entities).toHaveLength(3);
       expect(entities[0]).toEqual({
         accuracy: 1,
-        end: 30,
-        len: 9,
-        entity: 'fromLocation',
-        sourceText: 'Barcelona',
-        start: 22,
-        type: 'between',
-        utteranceText: 'Barcelona',
-      });
-      expect(entities[1]).toEqual({
-        accuracy: 1,
         end: 15,
         len: 6,
         entity: 'toLocation',
@@ -453,6 +452,16 @@ describe('NER Manager', () => {
         start: 10,
         type: 'between',
         utteranceText: 'travel',
+      });
+      expect(entities[1]).toEqual({
+        accuracy: 1,
+        end: 30,
+        len: 9,
+        entity: 'fromLocation',
+        sourceText: 'Barcelona',
+        start: 22,
+        type: 'between',
+        utteranceText: 'Barcelona',
       });
       expect(entities[2]).toEqual({
         accuracy: 0.99,
@@ -514,9 +523,7 @@ describe('NER Manager', () => {
       );
       expect(entities).toBeDefined();
       expect(entities).toHaveLength(3);
-      expect(entities[0].utteranceText).toEqual('tomorrow');
-      expect(entities[0].entity).toEqual('date');
-      expect(entities[1]).toEqual({
+      expect(entities[0]).toEqual({
         accuracy: 1,
         end: 30,
         len: 9,
@@ -526,7 +533,7 @@ describe('NER Manager', () => {
         type: 'between',
         utteranceText: 'Barcelona',
       });
-      expect(entities[2]).toEqual({
+      expect(entities[1]).toEqual({
         accuracy: 0.99,
         end: 40,
         len: 6,
@@ -536,11 +543,133 @@ describe('NER Manager', () => {
         type: 'afterLast',
         utteranceText: 'Madrid',
       });
+      expect(entities[2].utteranceText).toEqual('tomorrow');
+      expect(entities[2].entity).toEqual('date');
+    });
+  });
+
+  describe('Find numbered entities', () => {
+    async function findEntities(utterance, whitelist) {
+      const manager = new NerManager();
+      manager.addNamedEntityText('hero', 'ironman', ['en'], ['iron man']);
+      manager.addNamedEntityText('hero', 'spiderman', ['en'], ['Spider-man']);
+      manager.addNamedEntityText('hero', 'thor', ['en'], ['Thor']);
+      manager.addNamedEntityText('food', 'pizza', ['en'], ['pizza']);
+      manager.addNamedEntityText('food', 'pasta', ['en'], ['spaghetti']);
+      return manager.findEntities(utterance, 'en', whitelist);
+    }
+    test('Should find numbered entities', async () => {
+      const entities = await findEntities(
+        'I saw spiderman eating spaghetti and ironman eating pizza',
+        ['hero_1', 'hero_2', 'food_1', 'food_2']
+      );
+      expect(entities).toBeDefined();
+      expect(entities).toHaveLength(4);
+      expect(entities[0].option).toEqual('spiderman');
+      expect(entities[0].sourceText).toEqual('Spider-man');
+      expect(entities[0].entity).toEqual('hero_1');
+      expect(entities[0].utteranceText).toEqual('spiderman');
+      expect(entities[1].option).toEqual('pasta');
+      expect(entities[1].sourceText).toEqual('spaghetti');
+      expect(entities[1].entity).toEqual('food_1');
+      expect(entities[1].utteranceText).toEqual('spaghetti');
+      expect(entities[2].option).toEqual('ironman');
+      expect(entities[2].sourceText).toEqual('iron man');
+      expect(entities[2].entity).toEqual('hero_2');
+      expect(entities[2].utteranceText).toEqual('ironman');
+      expect(entities[3].option).toEqual('pizza');
+      expect(entities[3].sourceText).toEqual('pizza');
+      expect(entities[3].entity).toEqual('food_2');
+      expect(entities[3].utteranceText).toEqual('pizza');
+    });
+    test('Should find numbered and non-numbered entities', async () => {
+      const entities = await findEntities(
+        'I saw spiderman together with ironman, they where eating spaghetti',
+        ['hero_1', 'hero_2', 'food']
+      );
+      expect(entities).toBeDefined();
+      expect(entities).toHaveLength(3);
+      expect(entities[0].option).toEqual('spiderman');
+      expect(entities[0].sourceText).toEqual('Spider-man');
+      expect(entities[0].entity).toEqual('hero_1');
+      expect(entities[0].utteranceText).toEqual('spiderman');
+      expect(entities[1].option).toEqual('ironman');
+      expect(entities[1].sourceText).toEqual('iron man');
+      expect(entities[1].entity).toEqual('hero_2');
+      expect(entities[1].utteranceText).toEqual('ironman');
+      expect(entities[2].option).toEqual('pasta');
+      expect(entities[2].sourceText).toEqual('spaghetti');
+      expect(entities[2].entity).toEqual('food');
+      expect(entities[2].utteranceText).toEqual('spaghetti');
+    });
+    test('Should assign the whitelist names to the entities', async () => {
+      const entities = await findEntities(
+        'I saw spiderman together with ironman, they where eating spaghetti',
+        ['hero', 'hero_2', 'food_6']
+      );
+      expect(entities).toBeDefined();
+      expect(entities).toHaveLength(3);
+      expect(entities[0].option).toEqual('spiderman');
+      expect(entities[0].sourceText).toEqual('Spider-man');
+      expect(entities[0].entity).toEqual('hero');
+      expect(entities[0].utteranceText).toEqual('spiderman');
+      expect(entities[1].option).toEqual('ironman');
+      expect(entities[1].sourceText).toEqual('iron man');
+      expect(entities[1].entity).toEqual('hero_2');
+      expect(entities[1].utteranceText).toEqual('ironman');
+      expect(entities[2].option).toEqual('pasta');
+      expect(entities[2].sourceText).toEqual('spaghetti');
+      expect(entities[2].entity).toEqual('food_6');
+      expect(entities[2].utteranceText).toEqual('spaghetti');
+    });
+    test('Should assign names to found entities in whitelist order', async () => {
+      const entities = await findEntities(
+        'I saw spiderman together with ironman, they where eating spaghetti',
+        ['hero_1', 'hero_2', 'hero_3', 'food_1', 'food_2']
+      );
+      expect(entities).toBeDefined();
+      expect(entities).toHaveLength(3);
+      expect(entities[0].option).toEqual('spiderman');
+      expect(entities[0].sourceText).toEqual('Spider-man');
+      expect(entities[0].entity).toEqual('hero_1');
+      expect(entities[0].utteranceText).toEqual('spiderman');
+      expect(entities[1].option).toEqual('ironman');
+      expect(entities[1].sourceText).toEqual('iron man');
+      expect(entities[1].entity).toEqual('hero_2');
+      expect(entities[1].utteranceText).toEqual('ironman');
+      expect(entities[2].option).toEqual('pasta');
+      expect(entities[2].sourceText).toEqual('spaghetti');
+      expect(entities[2].entity).toEqual('food_1');
+      expect(entities[2].utteranceText).toEqual('spaghetti');
+    });
+    test('Should use numbered names only once', async () => {
+      const entities = await findEntities(
+        'I saw spiderman eating spaghetti and ironman eating pizza',
+        ['hero_2', 'food_2']
+      );
+      expect(entities).toBeDefined();
+      expect(entities).toHaveLength(4);
+      expect(entities[0].option).toEqual('spiderman');
+      expect(entities[0].sourceText).toEqual('Spider-man');
+      expect(entities[0].entity).toEqual('hero_2');
+      expect(entities[0].utteranceText).toEqual('spiderman');
+      expect(entities[1].option).toEqual('pasta');
+      expect(entities[1].sourceText).toEqual('spaghetti');
+      expect(entities[1].entity).toEqual('food_2');
+      expect(entities[1].utteranceText).toEqual('spaghetti');
+      expect(entities[2].option).toEqual('ironman');
+      expect(entities[2].sourceText).toEqual('iron man');
+      expect(entities[2].entity).toEqual('hero');
+      expect(entities[2].utteranceText).toEqual('ironman');
+      expect(entities[3].option).toEqual('pizza');
+      expect(entities[3].sourceText).toEqual('pizza');
+      expect(entities[3].entity).toEqual('food');
+      expect(entities[3].utteranceText).toEqual('pizza');
     });
   });
 
   describe('Generate entity utterance', () => {
-    test('Should replace entities by they names', async () => {
+    test('Should replace entities by their names', async () => {
       const manager = new NerManager();
       manager.addNamedEntityText('hero', 'ironman', ['en'], ['ironman']);
       manager.addNamedEntityText('hero', 'thor', ['en'], ['Thor']);


### PR DESCRIPTION
## PR Checklist

- [x] I have run `npm test` locally and all tests are passing.
- [x] I have added/updated tests for any new behavior.
- [ ] If this is a significant change, an issue has already been created where the problem / solution was discussed: [N/A, or add link to issue here]

## PR Description

Support slot filling with more than one entity with the same name by providing "numbered entities". E.g. "I saw %hero_1% and %hero_2% fighting together".