### PR TITLE
added failing test for trimentity not matching word at string begin

### DIFF
--- a/test/ner/trim-named.entity.test.js
+++ b/test/ner/trim-named.entity.test.js
@@ -489,5 +489,21 @@ describe('Trim Named Entity', () => {
       const matchs = entity.extract('I must go from Barcelona to Madrid');
       expect(matchs).toHaveLength(7);
     });
+    test('It should be able to retrieve at start of utterance', () => {
+      const entity = new TrimNamedEntity({ name: 'fromLocation' });
+      entity.addAfterLastCondition('en', 'from');
+      const matchs = entity.extract('from Barcelona to Madrid');
+      expect(matchs).toHaveLength(1);
+      expect(matchs[0]).toEqual({
+        type: 'afterLast',
+        start: 5,
+        end: 23,
+        len: 19,
+        accuracy: 0.99,
+        sourceText: 'Barcelona to Madrid',
+        utteranceText: 'Barcelona to Madrid',
+        entity: 'fromLocation',
+      });
+    });
   });
 });


### PR DESCRIPTION
Tests are passing (but the one I added).
a "after" trim named entity will not find this:
```
const entity = new TrimNamedEntity({ name: 'fromLocation' });
entity.addAfterLastCondition('en', 'from');
const matchs = entity.extract('from Barcelona to Madrid'); 
```
Because the condition is the first word of the utterance. It would work if there are characters before the word.

# Pull Request Template

## PR Checklist

- [ ] I have run `npm test` locally and all tests are passing.
- [X] I have added/updated tests for any new behavior.
- [ ] If this is a significant change, an issue has already been created where the problem / solution was discussed: [N/A, or add link to issue here]

## PR Description

<!-- Describe Your PR Here! -->