### PR TITLE
build: finer grain import in BaseStemmer to reduce dependencies

### DIFF
--- a/lib/nlp/stemmers/base-stemmer.js
+++ b/lib/nlp/stemmers/base-stemmer.js
@@ -21,7 +21,7 @@
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-const { TreebankWordTokenizer } = require("../tokenizers");
+const TreebankWordTokenizer = require("../tokenizers/treebank-word-tokenizer");
 
 class BaseStemmer {
   constructor(tokenizer, stopwords) {


### PR DESCRIPTION
# Pull Request Template

## PR Checklist

- [x] I have run `npm test` locally and all tests are passing.
- [x] I have added/updated tests for any new behavior.
- [x] If this is a significant change, an issue has already been created where the problem / solution was discussed: https://github.com/axa-group/nlp.js/issues/225

## PR Description

BaseStemmer.js imports all tokenizers, when it only needs TreebankWordTokenizer. Some of the tokenizers, like Japanese & Chinese, has special requirements, and the PR allows not importing them when they are not necessary