### PR TITLE
fix: Extended NER to support datetimerange

### DIFF
--- a/lib/ner/ner-recognizer.js
+++ b/lib/ner/ner-recognizer.js
@@ -71,6 +71,7 @@ class NerRecognizer {
       'timezone',
       'boolean',
       'duration',
+      'datetimerange',
     ];
     this.builtinWhitelist = {};
     for (let i = 0; i < list.length; i += 1) {
@@ -135,7 +136,8 @@ class NerRecognizer {
     }
     if (
       entity.typeName === 'datetimeV2.date' ||
-      entity.typeName === 'datetimeV2.daterange'
+      entity.typeName === 'datetimeV2.daterange' ||
+      entity.typeName === 'datetimeV2.datetimerange'
     ) {
       if (resolution.values) {
         if (resolution.values.length === 1) {
@@ -147,6 +149,10 @@ class NerRecognizer {
           if (resValue.value) {
             result.strValue = resValue.value;
             result.date = new Date(resValue.value);
+          } else if (resValue.start) {
+            result.start = new Date(resValue.start);
+            result.end = new Date(resValue.end);
+            result.date = new Date(resValue.start);
           }
           return result;
         }


### PR DESCRIPTION
# Pull Request Template

## PR Checklist

- [x] I have run `npm test` locally and all tests are passing.
- [ ] I have added/updated tests for any new behavior.
- [x] If this is a significant change, an issue has already been created where the problem / solution was discussed:  https://github.com/axa-group/nlp.js/issues/268

## PR Description

Added support for the datetimerange response from Microsoft Recognizers. This is triggered when a user says something like "tomorrow morning". I was working on adding tests for this but the date/time parsing doesn't currently support using a reference time. This should be added at a later time.