### PR TITLE
feat: use performance.now instead of process.hrtime

### DIFF
--- a/lib/classifiers/neural-network.js
+++ b/lib/classifiers/neural-network.js
@@ -21,6 +21,7 @@
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
+const { performance } = require('perf_hooks');
 const {
   LookupTable,
   toHash,
@@ -171,7 +172,7 @@ class NeuralNetwork {
       this.status.error > minError &&
       this.status.deltaError > minDelta
     ) {
-      const hrstart = process.hrtime();
+      const hrstart = performance.now();
       this.status.iterations += 1;
       const lastError = this.status.error;
       this.status.error = 0;
@@ -185,9 +186,9 @@ class NeuralNetwork {
       }
       this.status.error /= data.length;
       this.status.deltaError = Math.abs(this.status.error - lastError);
-      const hrend = process.hrtime(hrstart);
+      const hrend = performance.now();
       if (this.logFn) {
-        this.logFn(this.status, hrend[0] * 1000 + hrend[1] / 1000000);
+        this.logFn(this.status, hrend - hrstart);
       }
     }
     return this.status;


### PR DESCRIPTION
# Pull Request Template

## PR Checklist

- [X] I have run `npm test` locally and all tests are passing.
- [ ] I have added/updated tests for any new behavior.
- [ ] If this is a significant change, an issue has already been created where the problem / solution was discussed: [N/A, or add link to issue here]

## PR Description

Use performance.now instead of process.hrtime to have browser compatibility