### PR TITLE
fix: remove accents from SpanishStemmer

### DIFF
--- a/lib/nlp/stemmers/spanish-stemmer.js
+++ b/lib/nlp/stemmers/spanish-stemmer.js
@@ -1262,7 +1262,7 @@ SpanishStemmer.a_9 = [
   new Among('e', -1, 2),
   new Among('o', -1, 1),
   new Among('os', -1, 1),
-  new Among('i', -1, 1)
+  new Among('\u00ED', -1, 1)
 ];
 
 SpanishStemmer.g_v = [

--- a/lib/nlp/stemmers/spanish-stemmer.js
+++ b/lib/nlp/stemmers/spanish-stemmer.js
@@ -353,7 +353,7 @@ class SpanishStemmer extends BaseStemmer {
     // ], line 68
     this.bra = this.cursor;
     // substring, line 72
-    among_var = this.find_among_b(SpanishStemmer.a_2, 11);
+    among_var = this.find_among_b(SpanishStemmer.a_2, 6);
     if (among_var == 0) {
       return false;
     }
@@ -743,7 +743,7 @@ class SpanishStemmer extends BaseStemmer {
     // [, line 168
     this.ket = this.cursor;
     // substring, line 168
-    among_var = this.find_among_b(SpanishStemmer.a_7, 12);
+    among_var = this.find_among_b(SpanishStemmer.a_7, 11);
     if (among_var == 0) {
       this.limit_backward = v_2;
       return false;
@@ -790,7 +790,7 @@ class SpanishStemmer extends BaseStemmer {
     // [, line 176
     this.ket = this.cursor;
     // substring, line 176
-    among_var = this.find_among_b(SpanishStemmer.a_8, 96);
+    among_var = this.find_among_b(SpanishStemmer.a_8, 95);
     if (among_var == 0) {
       this.limit_backward = v_2;
       return false;
@@ -849,7 +849,7 @@ class SpanishStemmer extends BaseStemmer {
     // [, line 205
     this.ket = this.cursor;
     // substring, line 205
-    among_var = this.find_among_b(SpanishStemmer.a_9, 8);
+    among_var = this.find_among_b(SpanishStemmer.a_9, 5);
     if (among_var == 0) {
       return false;
     }
@@ -1042,11 +1042,11 @@ class SpanishStemmer extends BaseStemmer {
 }
 SpanishStemmer.a_0 = [
   new Among('', -1, 6),
-  new Among('\u00E1', 0, 1),
-  new Among('\u00E9', 0, 2),
-  new Among('\u00ED', 0, 3),
-  new Among('\u00F3', 0, 4),
-  new Among('\u00FA', 0, 5)
+  new Among('a', 0, 1),
+  new Among('e', 0, 2),
+  new Among('i', 0, 3),
+  new Among('o', 0, 4),
+  new Among('u', 0, 5)
 ];
 SpanishStemmer.a_1 = [
   new Among('la', -1, -1),
@@ -1068,14 +1068,9 @@ SpanishStemmer.a_2 = [
   new Among('ando', -1, 6),
   new Among('iendo', -1, 6),
   new Among('yendo', -1, 7),
-  new Among('\u00E1ndo', -1, 2),
-  new Among('i\u00E9ndo', -1, 1),
   new Among('ar', -1, 6),
   new Among('er', -1, 6),
-  new Among('ir', -1, 6),
-  new Among('\u00E1r', -1, 3),
-  new Among('\u00E9r', -1, 4),
-  new Among('\u00EDr', -1, 5)
+  new Among('ir', -1, 6)
 ];
 
 SpanishStemmer.a_3 = [
@@ -1106,15 +1101,15 @@ SpanishStemmer.a_6 = [
   new Among('ista', -1, 1),
   new Among('iva', -1, 9),
   new Among('anza', -1, 1),
-  new Among('log\u00EDa', -1, 3),
+  new Among('logia', -1, 3),
   new Among('idad', -1, 8),
   new Among('able', -1, 1),
   new Among('ible', -1, 1),
   new Among('ante', -1, 2),
   new Among('mente', -1, 7),
   new Among('amente', 13, 6),
-  new Among('aci\u00F3n', -1, 2),
-  new Among('uci\u00F3n', -1, 4),
+  new Among('acion', -1, 2),
+  new Among('ucion', -1, 4),
   new Among('ico', -1, 1),
   new Among('ismo', -1, 1),
   new Among('oso', -1, 1),
@@ -1130,7 +1125,7 @@ SpanishStemmer.a_6 = [
   new Among('istas', -1, 1),
   new Among('ivas', -1, 9),
   new Among('anzas', -1, 1),
-  new Among('log\u00EDas', -1, 3),
+  new Among('logias', -1, 3),
   new Among('idades', -1, 8),
   new Among('ables', -1, 1),
   new Among('ibles', -1, 1),
@@ -1157,8 +1152,7 @@ SpanishStemmer.a_7 = [
   new Among('yas', -1, 1),
   new Among('yes', -1, 1),
   new Among('yais', -1, 1),
-  new Among('yamos', -1, 1),
-  new Among('y\u00F3', -1, 1)
+  new Among('yamos', -1, 1)
 ];
 
 SpanishStemmer.a_8 = [
@@ -1167,10 +1161,10 @@ SpanishStemmer.a_8 = [
   new Among('ida', -1, 2),
   new Among('ara', -1, 2),
   new Among('iera', -1, 2),
-  new Among('\u00EDa', -1, 2),
-  new Among('ar\u00EDa', 5, 2),
-  new Among('er\u00EDa', 5, 2),
-  new Among('ir\u00EDa', 5, 2),
+  new Among('ia', -1, 2),
+  new Among('aria', 5, 2),
+  new Among('eria', 5, 2),
+  new Among('iria', 5, 2),
   new Among('ad', -1, 2),
   new Among('ed', -1, 2),
   new Among('id', -1, 2),
@@ -1182,18 +1176,18 @@ SpanishStemmer.a_8 = [
   new Among('aban', 16, 2),
   new Among('aran', 16, 2),
   new Among('ieran', 16, 2),
-  new Among('\u00EDan', 16, 2),
-  new Among('ar\u00EDan', 20, 2),
-  new Among('er\u00EDan', 20, 2),
-  new Among('ir\u00EDan', 20, 2),
+  new Among('ian', 16, 2),
+  new Among('arian', 20, 2),
+  new Among('erian', 20, 2),
+  new Among('irian', 20, 2),
   new Among('en', -1, 1),
   new Among('asen', 24, 2),
   new Among('iesen', 24, 2),
   new Among('aron', -1, 2),
   new Among('ieron', -1, 2),
-  new Among('ar\u00E1n', -1, 2),
-  new Among('er\u00E1n', -1, 2),
-  new Among('ir\u00E1n', -1, 2),
+  new Among('aran', -1, 2),
+  new Among('eran', -1, 2),
+  new Among('iran', -1, 2),
   new Among('ado', -1, 2),
   new Among('ido', -1, 2),
   new Among('ando', -1, 2),
@@ -1207,57 +1201,60 @@ SpanishStemmer.a_8 = [
   new Among('idas', 39, 2),
   new Among('aras', 39, 2),
   new Among('ieras', 39, 2),
-  new Among('\u00EDas', 39, 2),
-  new Among('ar\u00EDas', 45, 2),
-  new Among('er\u00EDas', 45, 2),
-  new Among('ir\u00EDas', 45, 2),
+// conditional
+  new Among('ias', 39, 2),
+  new Among('arias', 45, 2),
+  new Among('erias', 45, 2),
+  new Among('irias', 45, 2),
+// subjunctive
   new Among('es', -1, 1),
   new Among('ases', 49, 2),
   new Among('ieses', 49, 2),
   new Among('abais', -1, 2),
   new Among('arais', -1, 2),
   new Among('ierais', -1, 2),
-  new Among('\u00EDais', -1, 2),
-  new Among('ar\u00EDais', 55, 2),
-  new Among('er\u00EDais', 55, 2),
-  new Among('ir\u00EDais', 55, 2),
+  new Among('iais', -1, 2),
+  new Among('ariais', 55, 2),
+  new Among('eriais', 55, 2),
+  new Among('iriais', 55, 2),
   new Among('aseis', -1, 2),
   new Among('ieseis', -1, 2),
   new Among('asteis', -1, 2),
   new Among('isteis', -1, 2),
-  new Among('\u00E1is', -1, 2),
-  new Among('\u00E9is', -1, 1),
-  new Among('ar\u00E9is', 64, 2),
-  new Among('er\u00E9is', 64, 2),
-  new Among('ir\u00E9is', 64, 2),
+  new Among('ais', -1, 2),
+  new Among('eis', -1, 1),
+  new Among('areis', 64, 2),
+  new Among('ereis', 64, 2),
+  new Among('ireis', 64, 2),
   new Among('ados', -1, 2),
   new Among('idos', -1, 2),
   new Among('amos', -1, 2),
-  new Among('\u00E1bamos', 70, 2),
-  new Among('\u00E1ramos', 70, 2),
-  new Among('i\u00E9ramos', 70, 2),
-  new Among('\u00EDamos', 70, 2),
-  new Among('ar\u00EDamos', 74, 2),
-  new Among('er\u00EDamos', 74, 2),
-  new Among('ir\u00EDamos', 74, 2),
+  new Among('abamos', 70, 2),
+  new Among('aramos', 70, 2),
+  new Among('ieramos', 70, 2),
+  new Among('iamos', 70, 2),
+  new Among('ariamos', 74, 2),
+  new Among('eriamos', 74, 2),
+  new Among('iriamos', 74, 2),
   new Among('emos', -1, 1),
   new Among('aremos', 78, 2),
   new Among('eremos', 78, 2),
   new Among('iremos', 78, 2),
-  new Among('\u00E1semos', 78, 2),
-  new Among('i\u00E9semos', 78, 2),
+  new Among('asemos', 78, 2),
+  new Among('iesemos', 78, 2),
   new Among('imos', -1, 2),
-  new Among('ar\u00E1s', -1, 2),
-  new Among('er\u00E1s', -1, 2),
-  new Among('ir\u00E1s', -1, 2),
-  new Among('\u00EDs', -1, 2),
-  new Among('ar\u00E1', -1, 2),
-  new Among('er\u00E1', -1, 2),
-  new Among('ir\u00E1', -1, 2),
-  new Among('ar\u00E9', -1, 2),
-  new Among('er\u00E9', -1, 2),
-  new Among('ir\u00E9', -1, 2),
-  new Among('i\u00F3', -1, 2)
+  new Among('aras', -1, 2),
+  new Among('eras', -1, 2),
+  new Among('iras', -1, 2),
+  new Among('is', -1, 2),
+// future
+  new Among('era', -1, 2),
+  new Among('ira', -1, 2),
+  new Among('are', -1, 2),
+  new Among('ere', -1, 2),
+  new Among('ire', -1, 2),
+// perfect past
+  new Among('io', -1, 2)
 ];
 
 SpanishStemmer.a_9 = [
@@ -1265,10 +1262,7 @@ SpanishStemmer.a_9 = [
   new Among('e', -1, 2),
   new Among('o', -1, 1),
   new Among('os', -1, 1),
-  new Among('\u00E1', -1, 1),
-  new Among('\u00E9', -1, 2),
-  new Among('\u00ED', -1, 1),
-  new Among('\u00F3', -1, 1)
+  new Among('i', -1, 1)
 ];
 
 SpanishStemmer.g_v = [

--- a/lib/nlp/stemmers/spanish-stemmer.js
+++ b/lib/nlp/stemmers/spanish-stemmer.js
@@ -1242,7 +1242,6 @@ SpanishStemmer.a_8 = [
   new Among('iremos', 78, 2),
   new Among('asemos', 78, 2),
   new Among('iesemos', 78, 2),
-  new Among('imos', -1, 2),
   new Among('aras', -1, 2),
   new Among('eras', -1, 2),
   new Among('iras', -1, 2),
@@ -1254,7 +1253,8 @@ SpanishStemmer.a_8 = [
   new Among('ere', -1, 2),
   new Among('ire', -1, 2),
 // perfect past
-  new Among('io', -1, 2)
+  new Among('io', -1, 2),
+  new Among('imos', -1, 2),
 ];
 
 SpanishStemmer.a_9 = [

--- a/test/nlp/stemmers/spanish-stemmer.test.js
+++ b/test/nlp/stemmers/spanish-stemmer.test.js
@@ -33,11 +33,11 @@ describe('Spanish Stemmer', () => {
   describe('Stem', () => {
     test('Should tokenize and stem spanish text', () => {
       const text =
-        'Me compraría una gato trepadora perfectamente si lo considerara aconsejable';
+        'Amigos, compraría una gato trepadora perfectamente si lo considerara aconsejable';
       const stemmer = NlpUtil.getStemmer('es');
       const actual = stemmer.tokenizeAndStem(text);
       const expected = [
-        'me',
+        'amig',
         'compr',
         'una',
         'gat',

--- a/test/nlp/stemmers/spanish-stemmer.test.js
+++ b/test/nlp/stemmers/spanish-stemmer.test.js
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) AXA Group Operations Spain S.A.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+const { NlpUtil } = require('../../../lib');
+
+describe('Spanish Stemmer', () => {
+  describe('Constructor', () => {
+    test('It should create a new instance', () => {
+      const stemmer = NlpUtil.getStemmer('gl');
+      expect(stemmer).toBeDefined();
+    });
+  });
+  describe('Stem', () => {
+    test('Should tokenize and stem spanish text', () => {
+      const text =
+        'Me compraría una gato trepadora perfectamente si lo considerara aconsejable';
+      const stemmer = NlpUtil.getStemmer('es');
+      const actual = stemmer.tokenizeAndStem(text);
+      const expected = [
+        'me',
+        'compr',
+        'una',
+        'gat',
+        'trepador', // TODO should be trep
+        'perfect',
+        'si',
+        'lo',
+        'considerar', // TODO should be consider
+        'aconsej',
+      ];
+      expect(actual).toEqual(expected);
+    });
+  });
+});

--- a/test/nlp/stemmers/spanish-stemmer.test.js
+++ b/test/nlp/stemmers/spanish-stemmer.test.js
@@ -33,13 +33,14 @@ describe('Spanish Stemmer', () => {
   describe('Stem', () => {
     test('Should tokenize and stem spanish text', () => {
       const text =
-        'Amigos, compraría una gato trepadora perfectamente si lo considerara aconsejable';
+        'Amigos, nos aburrimos. Compraría gato trepador perfectamente si lo considerara aconsejable y reiremos';
       const stemmer = NlpUtil.getStemmer('es');
       const actual = stemmer.tokenizeAndStem(text);
       const expected = [
         'amig',
+        'nos',
+        'aburr',
         'compr',
-        'una',
         'gat',
         'trepador', // TODO should be trep
         'perfect',
@@ -47,6 +48,8 @@ describe('Spanish Stemmer', () => {
         'lo',
         'considerar', // TODO should be consider
         'aconsej',
+        'y',
+        'reir',
       ];
       expect(actual).toEqual(expected);
     });


### PR DESCRIPTION
added unit test for Spanish.
"trepadora" and "considerara" are still not correctly stemmed

# Pull Request Template

## PR Checklist

- [x] I have run `npm test` locally and all tests are passing.
- [x] I have added/updated tests for any new behavior.
- [ ] If this is a significant change, an issue has already been created where the problem / solution was discussed: [N/A, or add link to issue here]

## PR Description

SpanishStemmer was not compatible with AggressiveTokenizerEs, because the latter removes the accents, and the former was expecting them
