### PR TITLE
feat(actions): add logic to process actions

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -9,7 +9,9 @@
         "singleQuote": true,
         "trailingComma": "es5"
       }
-    ]
+    ],
+    "no-restricted-syntax": 0,
+    "no-await-in-loop": "off"
   },
   "env": {
     "node": true,

--- a/lib/nlg/action-manager.js
+++ b/lib/nlg/action-manager.js
@@ -29,7 +29,8 @@ class ActionManager {
   /**
    * Constructor of the class
    */
-  constructor() {
+  constructor(actionsMap) {
+    this.actionsMap = actionsMap;
     this.actions = {};
   }
 
@@ -37,7 +38,7 @@ class ActionManager {
    * Find the index of an action
    * @param {String} intent Name of the intent.
    * @param {String} action Name of the action.
-   * @param {String} parameters Parameters of the action.
+   * @param {String[]} list of parameters Parameters of the action.
    */
   posAction(intent, action, parameters) {
     if (!this.actions[intent]) {
@@ -47,7 +48,7 @@ class ActionManager {
     for (let i = 0; i < actions.length; i += 1) {
       if (
         actions[i].action === action &&
-        actions[i].parameters === parameters
+        actions[i].parameters.toString() === parameters.toString()
       ) {
         return i;
       }
@@ -61,7 +62,30 @@ class ActionManager {
    * @returns {Object[]} Actions for this intent.
    */
   findActions(intent) {
-    return this.actions[intent] || [];
+    const dehydratedActions = this.actions[intent] || [];
+
+    return dehydratedActions.map(actionBundle => {
+      return {
+        ...actionBundle,
+        fn: this.actionsMap[actionBundle.action],
+      };
+    });
+  }
+
+  /**
+   * Returns a processed answer after execute a list of given actions.
+   * @param {String} intent Name of the intent.
+   * @param {String} original answer
+   */
+  async processActions(intent, answer) {
+    const actionList = this.findActions(intent);
+    let processedAnswer = answer;
+
+    for (const { fn, parameters } of actionList) {
+      processedAnswer = await fn(processedAnswer, ...parameters);
+    }
+
+    return processedAnswer;
   }
 
   /**
@@ -98,6 +122,14 @@ class ActionManager {
    */
   removeActions(intent) {
     delete this.actions[intent];
+  }
+
+  /**
+   * Remove an action from the actions map.
+   * @param {String} action Name of the action.
+   */
+  removeActionFromMap(action) {
+    delete this.actionsMap[action];
   }
 }
 

--- a/lib/nlp/nlp-manager.js
+++ b/lib/nlp/nlp-manager.js
@@ -223,7 +223,7 @@ class NlpManager {
    * Add an action to a given intent.
    * @param {String} intent Name of the intent.
    * @param {String} action Action to be executed
-   * @param {String} parameters Parameters of the action
+   * @param {String[]} list of parameters Parameters of the action
    */
   addAction(intent, action, parameters) {
     this.actionManager.addAction(intent, action, parameters);
@@ -233,7 +233,7 @@ class NlpManager {
    * Remove an action.
    * @param {String} intent Name of the intent
    * @param {String} action Name of the action
-   * @param {String} parameters Parameters of the action.
+   * @param {String[]} parameters Parameters of the action.
    */
   removeAction(intent, action, parameters) {
     this.actionManager.removeAction(intent, action, parameters);
@@ -332,6 +332,16 @@ class NlpManager {
   }
 
   /**
+   * Returns a processed answer after related with an intent.
+   * @param {String} intent Name of the intent.
+   * @param {String} original answer.
+   * @returns {String} Processed answer.
+   */
+  processActions(intent, answer) {
+    return this.actionManager.processActions(intent, answer);
+  }
+
+  /**
    * Process to extract entities from an utterance.
    * @param {string} srcLocale Locale of the utterance, optional.
    * @param {string} srcUtterance Text of the utterance.
@@ -426,8 +436,12 @@ class NlpManager {
       result.localeIso2,
       result.utterance
     );
-    const answer = this.getAnswer(result.localeIso2, result.intent, context);
+    let answer = this.getAnswer(result.localeIso2, result.intent, context);
+
     result.actions = this.getActions(result.intent);
+
+    answer = await this.processActions(result.intent, answer);
+
     if (answer) {
       result.srcAnswer = answer;
       result.answer = Handlebars.compile(answer)(context);

--- a/test/nlg/action-manager.test.js
+++ b/test/nlg/action-manager.test.js
@@ -38,110 +38,203 @@ describe('Action Manager', () => {
   describe('Add actions', () => {
     test('Should be able to add an action to an intent', () => {
       const manager = new ActionManager();
-      manager.addAction('intent1', 'action1', 'parameter1,parameter2');
+      manager.addAction('intent1', 'action1', ['parameter1', 'parameter2']);
       expect(manager.actions.intent1).toHaveLength(1);
       expect(manager.actions.intent1[0].action).toEqual('action1');
-      expect(manager.actions.intent1[0].parameters).toEqual(
-        'parameter1,parameter2'
-      );
+      expect(manager.actions.intent1[0].parameters).toEqual([
+        'parameter1',
+        'parameter2',
+      ]);
     });
     test('If the same action is added, then avoid it', () => {
       const manager = new ActionManager();
-      manager.addAction('intent1', 'action1', 'parameter1,parameter2');
-      manager.addAction('intent1', 'action1', 'parameter1,parameter2');
+      manager.addAction('intent1', 'action1', ['parameter1', 'parameter2']);
+      manager.addAction('intent1', 'action1', ['parameter1', 'parameter2']);
       expect(manager.actions.intent1).toHaveLength(1);
       expect(manager.actions.intent1[0].action).toEqual('action1');
-      expect(manager.actions.intent1[0].parameters).toEqual(
-        'parameter1,parameter2'
-      );
+      expect(manager.actions.intent1[0].parameters).toEqual([
+        'parameter1',
+        'parameter2',
+      ]);
     });
     test('Should be able to add several actions to an intent', () => {
       const manager = new ActionManager();
-      manager.addAction('intent1', 'action1', 'parameter1,parameter2');
-      manager.addAction('intent1', 'action2', 'parameter3,parameter4');
+      manager.addAction('intent1', 'action1', ['parameter1', 'parameter2']);
+      manager.addAction('intent1', 'action2', ['parameter3', 'parameter4']);
       expect(manager.actions.intent1).toHaveLength(2);
       expect(manager.actions.intent1[0].action).toEqual('action1');
-      expect(manager.actions.intent1[0].parameters).toEqual(
-        'parameter1,parameter2'
-      );
+      expect(manager.actions.intent1[0].parameters).toEqual([
+        'parameter1',
+        'parameter2',
+      ]);
       expect(manager.actions.intent1[1].action).toEqual('action2');
-      expect(manager.actions.intent1[1].parameters).toEqual(
-        'parameter3,parameter4'
-      );
+      expect(manager.actions.intent1[1].parameters).toEqual([
+        'parameter3',
+        'parameter4',
+      ]);
     });
     test('Should be able to add several actions to several intents', () => {
       const manager = new ActionManager();
-      manager.addAction('intent1', 'action1', 'parameter1,parameter2');
-      manager.addAction('intent1', 'action2', 'parameter3,parameter4');
-      manager.addAction('intent2', 'action3', 'parameter5,parameter6');
-      manager.addAction('intent2', 'action4', 'parameter7,parameter8');
+      manager.addAction('intent1', 'action1', ['parameter1', 'parameter2']);
+      manager.addAction('intent1', 'action2', ['parameter3', 'parameter4']);
+      manager.addAction('intent2', 'action3', ['parameter5', 'parameter6']);
+      manager.addAction('intent2', 'action4', ['parameter7', 'parameter8']);
       expect(manager.actions.intent1).toHaveLength(2);
       expect(manager.actions.intent1[0].action).toEqual('action1');
-      expect(manager.actions.intent1[0].parameters).toEqual(
-        'parameter1,parameter2'
-      );
+      expect(manager.actions.intent1[0].parameters).toEqual([
+        'parameter1',
+        'parameter2',
+      ]);
       expect(manager.actions.intent1[1].action).toEqual('action2');
-      expect(manager.actions.intent1[1].parameters).toEqual(
-        'parameter3,parameter4'
-      );
+      expect(manager.actions.intent1[1].parameters).toEqual([
+        'parameter3',
+        'parameter4',
+      ]);
       expect(manager.actions.intent2).toHaveLength(2);
       expect(manager.actions.intent2[0].action).toEqual('action3');
-      expect(manager.actions.intent2[0].parameters).toEqual(
-        'parameter5,parameter6'
-      );
+      expect(manager.actions.intent2[0].parameters).toEqual([
+        'parameter5',
+        'parameter6',
+      ]);
       expect(manager.actions.intent2[1].action).toEqual('action4');
-      expect(manager.actions.intent2[1].parameters).toEqual(
-        'parameter7,parameter8'
-      );
+      expect(manager.actions.intent2[1].parameters).toEqual([
+        'parameter7',
+        'parameter8',
+      ]);
     });
   });
 
   describe('find actions', () => {
     test('Should be able to find actions of an intent', () => {
       const manager = new ActionManager();
-      manager.addAction('intent1', 'action1', 'parameter1,parameter2');
-      manager.addAction('intent1', 'action2', 'parameter3,parameter4');
-      manager.addAction('intent2', 'action3', 'parameter5,parameter6');
-      manager.addAction('intent2', 'action4', 'parameter7,parameter8');
+      manager.actionsMap = {
+        action1: input => input,
+        action2: input => input,
+        action3: input => input,
+        action4: input => input,
+      };
+      manager.addAction('intent1', 'action1', ['parameter1', 'parameter2']);
+      manager.addAction('intent1', 'action2', ['parameter3', 'parameter4']);
+      manager.addAction('intent2', 'action3', ['parameter5', 'parameter6']);
+      manager.addAction('intent2', 'action4', ['parameter7', 'parameter8']);
+
       const actions = manager.findActions('intent2');
+
       expect(actions).toHaveLength(2);
       expect(actions[0].action).toEqual('action3');
-      expect(actions[0].parameters).toEqual('parameter5,parameter6');
+      expect(actions[0].parameters).toEqual(['parameter5', 'parameter6']);
       expect(actions[1].action).toEqual('action4');
-      expect(actions[1].parameters).toEqual('parameter7,parameter8');
+      expect(actions[1].parameters).toEqual(['parameter7', 'parameter8']);
+    });
+  });
+
+  describe('process actions (sync)', () => {
+    test('Should be able to get an answered after process sync actions related with an intent', async () => {
+      const manager = new ActionManager();
+      manager.actionsMap = {
+        action1: (input, ...parameters) => `[${input}!${parameters.join(',')}]`,
+        action2: (input, ...parameters) => `#${input}!${parameters.join(',')}#`,
+      };
+      manager.addAction('intent1', 'action1', ['parameter1', 'parameter2']);
+      manager.addAction('intent1', 'action2', ['parameter3', 'parameter4']);
+      manager.addAction('intent1', 'action1', ['parameter5', 'parameter6']);
+
+      const actions = manager.findActions('intent1');
+
+      const processedAnswer = await manager.processActions(
+        'intent1',
+        'original answer'
+      );
+
+      expect(actions).toHaveLength(3);
+      expect(actions[0].action).toEqual('action1');
+      expect(actions[0].parameters).toEqual(['parameter1', 'parameter2']);
+      expect(actions[1].action).toEqual('action2');
+      expect(actions[1].parameters).toEqual(['parameter3', 'parameter4']);
+      expect(actions[2].action).toEqual('action1');
+      expect(actions[2].parameters).toEqual(['parameter5', 'parameter6']);
+      expect(processedAnswer).toEqual(
+        '[#[original answer!parameter1,parameter2]!parameter3,parameter4#!parameter5,parameter6]'
+      );
+    });
+  });
+
+  describe('process actions (async)', () => {
+    test('Should be able to get an answered after process async actions related with an intent', async () => {
+      const manager = new ActionManager();
+      manager.actionsMap = {
+        action1: (input, ...parameters) => {
+          return new Promise(resolve => {
+            setTimeout(() => {
+              resolve(`[${input}!${parameters.join(',')}]`);
+            }, 0.3);
+          });
+        },
+        action2: (input, ...parameters) => {
+          return new Promise(resolve => {
+            setTimeout(() => {
+              resolve(`#${input}!${parameters.join(',')}#`);
+            }, 0.1);
+          });
+        },
+      };
+      manager.addAction('intent1', 'action1', ['parameter1', 'parameter2']);
+      manager.addAction('intent1', 'action2', ['parameter3', 'parameter4']);
+      manager.addAction('intent1', 'action1', ['parameter5', 'parameter6']);
+
+      const actions = manager.findActions('intent1');
+
+      const processedAnswer = await manager.processActions(
+        'intent1',
+        'original answer'
+      );
+
+      expect(actions).toHaveLength(3);
+      expect(actions[0].action).toEqual('action1');
+      expect(actions[0].parameters).toEqual(['parameter1', 'parameter2']);
+      expect(actions[1].action).toEqual('action2');
+      expect(actions[1].parameters).toEqual(['parameter3', 'parameter4']);
+      expect(actions[2].action).toEqual('action1');
+      expect(actions[2].parameters).toEqual(['parameter5', 'parameter6']);
+      expect(processedAnswer).toEqual(
+        '[#[original answer!parameter1,parameter2]!parameter3,parameter4#!parameter5,parameter6]'
+      );
     });
   });
 
   describe('remove action', () => {
     test('Should be able to remove an action', () => {
       const manager = new ActionManager();
-      manager.addAction('intent1', 'action1', 'parameter1,parameter2');
-      manager.addAction('intent1', 'action2', 'parameter3,parameter4');
-      manager.addAction('intent2', 'action3', 'parameter5,parameter6');
-      manager.addAction('intent2', 'action4', 'parameter7,parameter8');
-      manager.removeAction('intent1', 'action2', 'parameter3,parameter4');
+      manager.addAction('intent1', 'action1', ['parameter1', 'parameter2']);
+      manager.addAction('intent1', 'action2', ['parameter3', 'parameter4']);
+      manager.addAction('intent2', 'action3', ['parameter5', 'parameter6']);
+      manager.addAction('intent2', 'action4', ['parameter7', 'parameter8']);
+      manager.removeAction('intent1', 'action2', ['parameter3', 'parameter4']);
       expect(manager.actions.intent1).toHaveLength(1);
       expect(manager.actions.intent1[0].action).toEqual('action1');
-      expect(manager.actions.intent1[0].parameters).toEqual(
-        'parameter1,parameter2'
-      );
+      expect(manager.actions.intent1[0].parameters).toEqual([
+        'parameter1',
+        'parameter2',
+      ]);
       expect(manager.actions.intent2).toHaveLength(2);
       expect(manager.actions.intent2[0].action).toEqual('action3');
-      expect(manager.actions.intent2[0].parameters).toEqual(
-        'parameter5,parameter6'
-      );
+      expect(manager.actions.intent2[0].parameters).toEqual([
+        'parameter5',
+        'parameter6',
+      ]);
       expect(manager.actions.intent2[1].action).toEqual('action4');
-      expect(manager.actions.intent2[1].parameters).toEqual(
-        'parameter7,parameter8'
-      );
+      expect(manager.actions.intent2[1].parameters).toEqual([
+        'parameter7',
+        'parameter8',
+      ]);
     });
     test('No error if removing non existing action', () => {
       const manager = new ActionManager();
-      manager.addAction('intent1', 'action1', 'parameter1,parameter2');
-      manager.addAction('intent1', 'action2', 'parameter3,parameter4');
-      manager.addAction('intent2', 'action3', 'parameter5,parameter6');
-      manager.addAction('intent2', 'action4', 'parameter7,parameter8');
-      manager.removeAction('intent1', 'action3', 'parameter3,parameter4');
+      manager.addAction('intent1', 'action1', ['parameter1', 'parameter2']);
+      manager.addAction('intent1', 'action2', ['parameter3', 'parameter4']);
+      manager.addAction('intent2', 'action3', ['parameter5', 'parameter6']);
+      manager.addAction('intent2', 'action4', ['parameter7', 'parameter8']);
+      manager.removeAction('intent1', 'action3', ['parameter3', 'parameter4']);
       expect(manager.actions.intent1).toHaveLength(2);
       expect(manager.actions.intent2).toHaveLength(2);
     });
@@ -149,21 +242,23 @@ describe('Action Manager', () => {
   describe('remove actions', () => {
     test('Should be able to remove all actions of an intent', () => {
       const manager = new ActionManager();
-      manager.addAction('intent1', 'action1', 'parameter1,parameter2');
-      manager.addAction('intent1', 'action2', 'parameter3,parameter4');
-      manager.addAction('intent2', 'action3', 'parameter5,parameter6');
-      manager.addAction('intent2', 'action4', 'parameter7,parameter8');
+      manager.addAction('intent1', 'action1', ['parameter1', 'parameter2']);
+      manager.addAction('intent1', 'action2', ['parameter3', 'parameter4']);
+      manager.addAction('intent2', 'action3', ['parameter5', 'parameter6']);
+      manager.addAction('intent2', 'action4', ['parameter7', 'parameter8']);
       manager.removeActions('intent1');
       expect(manager.actions.intent1).toBeUndefined();
       expect(manager.actions.intent2).toHaveLength(2);
       expect(manager.actions.intent2[0].action).toEqual('action3');
-      expect(manager.actions.intent2[0].parameters).toEqual(
-        'parameter5,parameter6'
-      );
+      expect(manager.actions.intent2[0].parameters).toEqual([
+        'parameter5',
+        'parameter6',
+      ]);
       expect(manager.actions.intent2[1].action).toEqual('action4');
-      expect(manager.actions.intent2[1].parameters).toEqual(
-        'parameter7,parameter8'
-      );
+      expect(manager.actions.intent2[1].parameters).toEqual([
+        'parameter7',
+        'parameter8',
+      ]);
     });
   });
 });


### PR DESCRIPTION
# Pull Request Template

## PR Checklist

- [x] I have run `npm test` locally and all tests are passing.
- [x] I have added/updated tests for any new behavior.
- [ ] If this is a significant change, an issue has already been created where the problem / solution was discussed: [N/A, or add link to issue here]

## PR Description

Implemented logic to process actions. It also works with async actions.
A map of actions can be set during the init of NlpManager and after is possible to relate intent with action passing custom parameters.
It's also possible to reuse the same action with different parameters in the same intent.

Example of usage:
```
      const manager = new NlpManager({
        languages: ['en'],
        action: { // I suggest to call it actionMap
          action1: (input, ...parameters) => {
            return `(${input}#${parameters.join(',')})`;
          },
          action2: (input, ...parameters) => {
            return `[${input}#${parameters.join(',')}]`;
          },
        },
      });
      manager.addDocument('en', 'goodbye for now', 'greetings.bye');
      manager.addDocument('en', 'bye bye take care', 'greetings.bye');

      manager.addDocument('en', 'hello', 'greetings.hello');
      manager.addDocument('en', 'hi', 'greetings.hello');

      manager.addAction('greetings.bye', 'action1', ['a', 'b']);
      manager.addAction('greetings.bye', 'action2', ['c', 'd']);

      manager.addAnswer('en', 'greetings.bye', 'See you soon!');
      manager.addAnswer('en', 'greetings.hello', 'Hey there!');

      await manager.train();

      const result = await manager.process('goodbye');

      expect(result.answer).toEqual('[(See you soon!#a,b)#c,d]');
```