### PR TITLE
Make spellchecker importable/exportable

### DIFF
--- a/lib/nlu/base-nlu.js
+++ b/lib/nlu/base-nlu.js
@@ -257,6 +257,7 @@ class BaseNLU {
     const result = {};
     result.settings = this.settings;
     result.language = this.language;
+    result.spellCheckDistance = this.spellCheckDistance;
     result.keepStopwords = this.keepStopwords;
     result.docs = [];
     for (let i = 0; i < this.docs.length; i += 1) {
@@ -278,6 +279,7 @@ class BaseNLU {
     this.settings = obj.settings;
     this.language = obj.language;
     this.keepStopwords = obj.language;
+    this.spellCheckDistance = obj.spellCheckDistance;
     this.stemmer = this.settings.stemmer || NlpUtil.getStemmer(this.language);
     this.docs = obj.docs;
     for (let i = 0; i < this.docs.length; i += 1) {


### PR DESCRIPTION
# Pull Request Template

## PR Checklist

- [x] I have run `npm test` locally and all tests are passing.
- [x] I have added/updated tests for any new behavior.
- [x] If this is a significant change, an issue has already been created where the problem / solution was discussed: [N/A, or add link to issue here]

## PR Description

When trying to make a model using nlp.js-app and to export it using spellCheck, I found that exporting and importing left out the spellCheckDistance property from base-nlu.

I tried the fix locally and it works so yeah :D