### PR TITLE
feat: optimize ExtractorEnum.getBestSubstringList

### DIFF
--- a/packages/ner/src/extractor-enum.js
+++ b/packages/ner/src/extractor-enum.js
@@ -147,6 +147,7 @@ class ExtractorEnum {
       }
       return result;
     }
+    const maxLevenshtein = str2len * (1 - threshold);
     const wordPositions = words1 || this.getWordPositions(str1);
     const wordPositionsLen = wordPositions.length;
     for (let i = 0; i < wordPositionsLen; i += 1) {
@@ -165,6 +166,12 @@ class ExtractorEnum {
             levenshtein,
             accuracy,
           });
+        }
+        if (
+          str3.length - wordPositions[0].len >=
+          str2.length + maxLevenshtein
+        ) {
+          break;
         }
       }
     }

--- a/packages/ner/test/extractor-enum.test.js
+++ b/packages/ner/test/extractor-enum.test.js
@@ -129,7 +129,7 @@ describe('Extractor Enum', () => {
   });
 
   describe('Get best substring list', () => {
-    test('If not threshold is defined, then search for exact occurences', () => {
+    test('If not threshold is defined, then search for exact occurrences', () => {
       const instance = new ExtractorEnum({ container });
       const text1 =
         'Morbi interdum ultricies neque varius condimentum. Donec volutpat turpis interdum metus ultricies vulputate. Duis ultricies rhoncus sapien, sit amet fermentum risus imperdiet vitae. Ut et lectus';
@@ -144,7 +144,7 @@ describe('Extractor Enum', () => {
         accuracy: 1,
       });
     });
-    test('If there are more than 1 occurence search exact, should return all', () => {
+    test('If there are more than 1 occurrence search exact, should return all', () => {
       const instance = new ExtractorEnum({ container });
       const text1 =
         'Morbi interdum ultricies neque varius condimentum. Donec volutpat turpis interdum metus ultricies vulputate. Duis ultricies rhoncus sapien, sit amet fermentum risus imperdiet vitae. Ut et lectus';
@@ -166,7 +166,7 @@ describe('Extractor Enum', () => {
         accuracy: 1,
       });
     });
-    test('Should get more than 1 occurence when searching with threshold', () => {
+    test('Should get more than 1 occurrence when searching with threshold', () => {
       const instance = new ExtractorEnum({ container });
       const text1 =
         'Morbi interdum ultricies neque varius condimentum. Donec volutpat turpis interdum metus ultricies vulputate. Duis ultricies rhoncus sapien, sit amet fermentum risus imperdiet vitae. Ut et lectus';
@@ -191,6 +191,33 @@ describe('Extractor Enum', () => {
         len: 8,
         levenshtein: 1,
         accuracy: 0.875,
+      });
+    });
+    test('Should be tolerant to typos with spaces when searching with threshold', () => {
+      const instance = new ExtractorEnum({ container });
+      const text1 =
+        'Morbi inter dum ultricies neque varius condimentum. Donec volutpat turpis in terdum';
+      const text2 = 'internum';
+      const result = instance.getBestSubstringList(
+        text1,
+        text2,
+        undefined,
+        1 - 2 / text2.length
+      );
+      expect(result).toHaveLength(2);
+      expect(result[0]).toEqual({
+        start: 6,
+        end: 14,
+        len: 9,
+        levenshtein: 2,
+        accuracy: 0.75,
+      });
+      expect(result[1]).toEqual({
+        start: 74,
+        end: 82,
+        len: 9,
+        levenshtein: 2,
+        accuracy: 0.75,
       });
     });
     test('Should return 0 to length element in array when the substring is longer than the string and accuracy is at least threshold', () => {


### PR DESCRIPTION
Don't concat the next word if doing it will never match with
the first word

# Pull Request Template

## PR Checklist

- [x] I have run `npm test` locally and all tests are passing.
- [x] I have added/updated tests for any new behavior.
- [N/A] If this is a significant change, an issue has already been created where the problem / solution was discussed: [N/A, or add link to issue here]

## PR Description

Making the most of the threshold argument of ExtractorEnum.getBestSubstringList, it is possible to implement a simple optimization which significally reduces the cost of the function. 
The algorithm checks the match of the 2nd string on each subsequence of words from the 1st string. The optimization consists on stop enlarging the subsequence once it's impossible that any match potentially obtained extending it with the next word requires the 1st word of the subsequence. At this point it's safe to shift right the first word of the 1st string subsequence  