### PR TITLE
Fix/pt tokenizer hiphen

### DIFF
--- a/packages/lang-pt/src/tokenizer-pt.js
+++ b/packages/lang-pt/src/tokenizer-pt.js
@@ -27,6 +27,10 @@ class TokenizerPt extends Tokenizer {
     super(container, shouldTokenize);
     this.name = 'tokenizer-pt';
   }
+
+  innerTokenize(text) {
+    return text.split(/[^a-zA-Zà-úÀ-Ú]/).filter(x => x);
+  }
 }
 
 module.exports = TokenizerPt;

--- a/packages/node-nlp/test/nlp/tokenizers/aggressive-tokenizer-it.test.js
+++ b/packages/node-nlp/test/nlp/tokenizers/aggressive-tokenizer-it.test.js
@@ -23,7 +23,7 @@
 
 const { NlpUtil } = require('../../../src/nlp');
 
-const tokenizer = NlpUtil.getTokenizer('fa');
+const tokenizer = NlpUtil.getTokenizer('it');
 
 describe('Aggressive Tokenizer It', () => {
   describe('Constructor', () => {

--- a/packages/node-nlp/test/nlp/tokenizers/aggressive-tokenizer-nl.test.js
+++ b/packages/node-nlp/test/nlp/tokenizers/aggressive-tokenizer-nl.test.js
@@ -23,7 +23,7 @@
 
 const { NlpUtil } = require('../../../src/nlp');
 
-const tokenizer = NlpUtil.getTokenizer('fa');
+const tokenizer = NlpUtil.getTokenizer('nl');
 
 describe('Aggressive Tokenizer Nl', () => {
   describe('Constructor', () => {

--- a/packages/node-nlp/test/nlp/tokenizers/aggressive-tokenizer-no.test.js
+++ b/packages/node-nlp/test/nlp/tokenizers/aggressive-tokenizer-no.test.js
@@ -23,7 +23,7 @@
 
 const { NlpUtil } = require('../../../src/nlp');
 
-const tokenizer = NlpUtil.getTokenizer('fa');
+const tokenizer = NlpUtil.getTokenizer('no');
 
 describe('Aggressive Tokenizer No', () => {
   describe('Constructor', () => {

--- a/packages/node-nlp/test/nlp/tokenizers/aggressive-tokenizer-pl.test.js
+++ b/packages/node-nlp/test/nlp/tokenizers/aggressive-tokenizer-pl.test.js
@@ -23,7 +23,7 @@
 
 const { NlpUtil } = require('../../../src/nlp');
 
-const tokenizer = NlpUtil.getTokenizer('fa');
+const tokenizer = NlpUtil.getTokenizer('pl');
 
 describe('Aggressive Tokenizer Pl', () => {
   describe('Constructor', () => {

--- a/packages/node-nlp/test/nlp/tokenizers/aggressive-tokenizer-pt.test.js
+++ b/packages/node-nlp/test/nlp/tokenizers/aggressive-tokenizer-pt.test.js
@@ -68,5 +68,10 @@ describe('Aggressive Tokenizer Pt', () => {
       );
       expect(actual).toEqual(expected);
     });
+    test('It must tokenize at hiphen', () => {
+      const expected = ['disse', 'me'];
+      const actual = tokenizer.tokenize('Disse-me', true);
+      expect(actual).toEqual(expected);
+    });
   });
 });

--- a/packages/node-nlp/test/nlp/tokenizers/aggressive-tokenizer-pt.test.js
+++ b/packages/node-nlp/test/nlp/tokenizers/aggressive-tokenizer-pt.test.js
@@ -23,7 +23,7 @@
 
 const { NlpUtil } = require('../../../src/nlp');
 
-const tokenizer = NlpUtil.getTokenizer('fa');
+const tokenizer = NlpUtil.getTokenizer('pt');
 
 describe('Aggressive Tokenizer Pt', () => {
   describe('Constructor', () => {

--- a/packages/node-nlp/test/nlp/tokenizers/aggressive-tokenizer-ru.test.js
+++ b/packages/node-nlp/test/nlp/tokenizers/aggressive-tokenizer-ru.test.js
@@ -23,7 +23,7 @@
 
 const { NlpUtil } = require('../../../src/nlp');
 
-const tokenizer = NlpUtil.getTokenizer('fa');
+const tokenizer = NlpUtil.getTokenizer('ru');
 
 describe('Aggressive Tokenizer Ru', () => {
   describe('Constructor', () => {

--- a/packages/node-nlp/test/nlp/tokenizers/aggressive-tokenizer-sv.test.js
+++ b/packages/node-nlp/test/nlp/tokenizers/aggressive-tokenizer-sv.test.js
@@ -23,7 +23,7 @@
 
 const { NlpUtil } = require('../../../src/nlp');
 
-const tokenizer = NlpUtil.getTokenizer('fa');
+const tokenizer = NlpUtil.getTokenizer('sv');
 
 describe('Aggressive Tokenizer Sv', () => {
   describe('Constructor', () => {


### PR DESCRIPTION
# Pull Request Template

## PR Checklist

- [x] I have run `npm test` locally and all tests are passing.
- [x] I have added/updated tests for any new behavior.
- [N/A] If this is a significant change, an issue has already been created where the problem / solution was discussed: [N/A, or add link to issue here]

## PR Description

In node.nlp 3.x, Portuguese tokenizer was able to tokenize "disse-me" into 2 words. This PR fixes the regression.
The PR also fixes the  tokenizer locales for some tests