### PR TITLE
fix bayes classifier coefficient with extra smoothing

### DIFF
--- a/lib/classifiers/bayes-classifier.js
+++ b/lib/classifiers/bayes-classifier.js
@@ -48,11 +48,11 @@ class BayesClassifier extends Classifier {
     const smoothing = this.smoothing || 1.0;
     let probability = 0;
 
-    const classTotal = this.observations[label].length;
+    const classTotal = this.observations[label].length + 1;
 
     observation.forEach((feature, index) => {
       if (feature) {
-        let count = 0;
+        let count = 1;
         this.observations[label].forEach(classObservation => {
           count += classObservation[index];
         });

--- a/test/nlu/bayes-nlu.test.js
+++ b/test/nlu/bayes-nlu.test.js
@@ -268,6 +268,18 @@ describe('Logistic Regression NLU', () => {
       expect(classifications[0].label).toEqual('keys');
       expect(classifications[0].value).toBeGreaterThan(0.7);
     });
+    it('Should work even for portuguese', async () => {
+      const nlu = new BayesNLU({ language: 'pt' });
+      nlu.add('oi', 'greet');
+      nlu.add('ola', 'greet');
+      nlu.add('quero ser contatado', 'contact');
+      nlu.add('entra em contato', 'contact');
+      await nlu.train();
+      const classifications = nlu.getClassifications('entra em contto');
+      expect(classifications).toHaveLength(2);
+      expect(classifications[0].label).toEqual('contact');
+      expect(classifications[0].value).toBeGreaterThan(0.7);
+    });
   });
 
   describe('Get Best Classification', () => {


### PR DESCRIPTION
# Pull Request Template

## PR Checklist

- [x] I have run `npm test` locally and all tests are passing.
- [x] I have added/updated tests for any new behavior.
- [x] If this is a significant change, an issue has already been created where the problem / solution was discussed: [N/A, or add link to issue here]

## PR Description

The bayes classifier were having a weird behaviour, returning right coefficients but associating with wrong labels. It was fixed incrementing initial counter, and total classes adding extra smotthing to coefficient product.