### PR TITLE
feat: reduce enum edges interesections choosing biggest one

### DIFF
--- a/packages/ner/src/reduce-edges.js
+++ b/packages/ner/src/reduce-edges.js
@@ -43,6 +43,18 @@ function runDiscard(srcEdge, srcOther, useMaxLength) {
       other.len > edge.len
     ) {
       edge.discarded = true;
+    } else if (edge.type === 'enum' && other.type === 'enum') {
+      if (
+        edge.len <= other.len &&
+        other.utteranceText.includes(edge.utteranceText)
+      ) {
+        edge.discarded = true;
+      } else if (
+        edge.len > other.len &&
+        edge.utteranceText.includes(other.utteranceText)
+      ) {
+        other.discarded = true;
+      }
     }
   }
 }


### PR DESCRIPTION
# Pull Request Template

## PR Checklist

- [X] I have run `npm test` locally and all tests are passing.
- [ ] I have added/updated tests for any new behavior.
- [X] If this is a significant change, an issue has already been created where the problem / solution was discussed: [N/A, or add link to issue here]

## PR Description

Solves https://github.com/axa-group/nlp.js/issues/388
When a text matches twice an entity and there is an overlapping, chose the biggest.
Example:
"good" and "very good". The sentence "This is very good" will match both, as "good" is contained into "very good" then the edge matching "good" is discarded.
