### PR TITLE
feat: TokenizerPt not to split words like covid-19

### DIFF
--- a/packages/lang-es/test/stemmer-es.test.js
+++ b/packages/lang-es/test/stemmer-es.test.js
@@ -85,5 +85,12 @@ describe('Stemmer', () => {
       const actual = stemmer.stem(tokens);
       expect(actual).toEqual(expected);
     });
+    test('Should stem "covid-19 covid19"', () => {
+      const input = 'covid-19 covid19';
+      const expected = ['covid-19', 'covid19'];
+      const tokens = tokenizer.tokenize(normalizer.normalize(input));
+      const actual = stemmer.stem(tokens);
+      expect(actual).toEqual(expected);
+    });
   });
 });

--- a/packages/lang-pt/test/stemmer-pt.test.js
+++ b/packages/lang-pt/test/stemmer-pt.test.js
@@ -20,17 +20,28 @@
  * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-const { Tokenizer } = require('@nlpjs/core');
 
-class TokenizerPt extends Tokenizer {
-  constructor(container, shouldTokenize) {
-    super(container, shouldTokenize);
-    this.name = 'tokenizer-pt';
-  }
+const { NormalizerPt, TokenizerPt, StemmerPt } = require('../src');
 
-  innerTokenize(text) {
-    return text.split(/[\s,.!?;:([\]'"¡¿)/]+|[-'](?=[a-zA-Z])/).filter(x => x);
-  }
-}
+const normalizer = new NormalizerPt();
+const tokenizer = new TokenizerPt();
+const stemmer = new StemmerPt();
 
-module.exports = TokenizerPt;
+describe('Stemmer', () => {
+  describe('Constructor', () => {
+    test('It should create a new instance', () => {
+      const instance = new StemmerPt();
+      expect(instance).toBeDefined();
+    });
+  });
+
+  describe('Stem', () => {
+    test('Should stem "disse-me o que sua empresa desenvolve?"', () => {
+      const input = 'disse-me o que sua empresa desenvolve?';
+      const expected = ['diss', 'me', 'o', 'que', 'sua', 'empres', 'desenvolv'];
+      const tokens = tokenizer.tokenize(normalizer.normalize(input));
+      const actual = stemmer.stem(tokens);
+      expect(actual).toEqual(expected);
+    });
+  });
+});

--- a/packages/lang-pt/test/tokenizer-pt.test.js
+++ b/packages/lang-pt/test/tokenizer-pt.test.js
@@ -20,17 +20,33 @@
  * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-const { Tokenizer } = require('@nlpjs/core');
 
-class TokenizerPt extends Tokenizer {
-  constructor(container, shouldTokenize) {
-    super(container, shouldTokenize);
-    this.name = 'tokenizer-pt';
-  }
+const { TokenizerPt } = require('../src');
 
-  innerTokenize(text) {
-    return text.split(/[\s,.!?;:([\]'"¡¿)/]+|[-'](?=[a-zA-Z])/).filter(x => x);
-  }
-}
+const tokenizer = new TokenizerPt();
 
-module.exports = TokenizerPt;
+describe('Tokenizer', () => {
+  describe('Constructor', () => {
+    test('It should create a new instance', () => {
+      const instance = new TokenizerPt();
+      expect(instance).toBeDefined();
+    });
+  });
+
+  describe('Tokenize', () => {
+    test('Should tokenize "disse-me DISSE-ME covid-19 COVID-19 covid19"', () => {
+      const input = 'disse-me DISSE-ME covid-19 COVID-19 covid19';
+      const expected = [
+        'disse',
+        'me',
+        'DISSE',
+        'ME',
+        'covid-19',
+        'COVID-19',
+        'covid19',
+      ];
+      const actual = tokenizer.tokenize(input);
+      expect(actual).toEqual(expected);
+    });
+  });
+});


### PR DESCRIPTION
# Pull Request Template

## PR Checklist

- [x] I have run `npm test` locally and all tests are passing.
- [x] I have added/updated tests for any new behavior.
- [N/A] If this is a significant change, an issue has already been created where the problem / solution was discussed: [N/A, or add link to issue here]

## PR Description

Portuguese tokenizer requires to split by "-" for words like "disse-me". However, it should not split words ending in "-" followed by a number, for words like "covid-19"