### PR TITLE
fix: don't crash if no intent is returned

### DIFF
--- a/packages/nlu/src/domain-manager.js
+++ b/packages/nlu/src/domain-manager.js
@@ -305,10 +305,16 @@ class DomainManager extends Clonable {
         classifications = nluAnswer.classifications;
         input.nluAnswer = nluAnswer;
       }
-      const finalDomain =
-        domainName === defaultDomainName
-          ? this.intentDict[classifications[0].intent]
-          : domainName;
+      let finalDomain;
+      if (domainName === defaultDomainName) {
+        if (classifications && classifications.length) {
+          finalDomain = this.intentDict[classifications[0].intent];
+        } else {
+          finalDomain = defaultDomainName;
+        }
+      } else {
+        finalDomain = domainName;
+      }
       input.classification = {
         domain: finalDomain,
         classifications,


### PR DESCRIPTION
# Pull Request Template

## PR Checklist

- [X] I have run `npm test` locally and all tests are passing.
- [X] I have added/updated tests for any new behavior.
- [X] If this is a significant change, an issue has already been created where the problem / solution was discussed: [N/A, or add link to issue here]

## PR Description

When no intent is returned put the default domain instead of crashing.
This should solve https://github.com/axa-group/nlp.js/issues/416