### PR TITLE
Serialize regex rules by using toString

### DIFF
--- a/packages/ner/src/ner.js
+++ b/packages/ner/src/ner.js
@@ -424,6 +424,7 @@ class Ner extends Clonable {
 
   toJSON() {
     // easy RegExp serialization: https://stackoverflow.com/questions/12075927/serialization-of-regexp
+    // eslint-disable-next-line no-extend-native
     RegExp.prototype.toJSON = RegExp.prototype.toString;
 
     const result = {


### PR DESCRIPTION
## PR Checklist

- [x] I have run `npm test` locally and all tests are passing.
- [ ] I have added/updated tests for any new behavior.
- [ ] If this is a significant change, an issue has already been created where the problem / solution was discussed: [N/A, or add link to issue here]

## PR Description

Fixes #431 by serializing `RegExp` objects using the `toString()` method when saving, but also using the `Ner.str2regex()` static method to parse stringified regex rules when loading a model.