### PR TITLE
feat: remove calculate deltas when no current error was found

### DIFF
--- a/packages/neural/src/neural-network.js
+++ b/packages/neural/src/neural-network.js
@@ -239,12 +239,6 @@ class NeuralNetwork extends Clonable {
           weights[k] += change;
         }
         perceptron.bias += delta;
-      } else {
-        for (let k; k < incoming.length; k += 1) {
-          const change = momentum * changes[k];
-          changes[k] = change;
-          weights[k] += change;
-        }
       }
     }
     return error / numOutputs;


### PR DESCRIPTION
# Pull Request Template

## PR Checklist

- [X] I have run `npm test` locally and all tests are passing.
- [X] I have added/updated tests for any new behavior.
- [X] If this is a significant change, an issue has already been created where the problem / solution was discussed: [N/A, or add link to issue here]

## PR Description
Don't calculate deltas when the current perceptron error is 0