### PR TITLE
Bump https-proxy-agent version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2994,7 +2994,8 @@
     "assertion-error": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
-      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw=="
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "dev": true
     },
     "assign-symbols": {
       "version": "1.0.0",
@@ -3449,6 +3450,7 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/chai/-/chai-4.2.0.tgz",
       "integrity": "sha512-XQU3bhBukrOsQCuwZndwGcCVQHyZi53fQ6Ys1Fym7E4olpIqqZZhhoFJoaKVvV17lWQoXYwgWN2nF5crA8J2jw==",
+      "dev": true,
       "requires": {
         "assertion-error": "^1.1.0",
         "check-error": "^1.0.2",
@@ -3478,7 +3480,8 @@
     "check-error": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
-      "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII="
+      "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
+      "dev": true
     },
     "chownr": {
       "version": "1.1.4",
@@ -4280,6 +4283,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
       "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
+      "dev": true,
       "requires": {
         "type-detect": "^4.0.0"
       }
@@ -5454,7 +5458,8 @@
     "get-func-name": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
-      "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE="
+      "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
+      "dev": true
     },
     "get-pkg-repo": {
       "version": "1.4.0",
@@ -9581,7 +9586,8 @@
     "pathval": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
-      "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA="
+      "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
+      "dev": true
     },
     "performance-now": {
       "version": "2.1.0",
@@ -11155,7 +11161,8 @@
     "type-detect": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
-      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g=="
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true
     },
     "type-fest": {
       "version": "0.8.1",

--- a/packages/request/package-lock.json
+++ b/packages/request/package-lock.json
@@ -5,47 +5,34 @@
 	"requires": true,
 	"dependencies": {
 		"agent-base": {
-			"version": "4.3.0",
-			"resolved": "https://axags.jfrog.io/axags/api/npm/virtual-bcn-node/agent-base/-/agent-base-4.3.0.tgz",
-			"integrity": "sha1-gWXwHENgCbzK0LHRIvBe13Dvxu4=",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.0.tgz",
+			"integrity": "sha512-j1Q7cSCqN+AwrmDd+pzgqc0/NpC655x2bUf5ZjRIO77DcNBFmh+OgRNzF6OKdCC9RSCb19fGd99+bhXFdkRNqw==",
 			"requires": {
-				"es6-promisify": "^5.0.0"
+				"debug": "4"
 			}
 		},
 		"debug": {
-			"version": "3.2.6",
-			"resolved": "https://axags.jfrog.io/axags/api/npm/virtual-bcn-node/debug/-/debug-3.2.6.tgz",
-			"integrity": "sha1-6D0X3hbYp++3cX7b5fsQE17uYps=",
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+			"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
 			"requires": {
 				"ms": "^2.1.1"
 			}
 		},
-		"es6-promise": {
-			"version": "4.2.8",
-			"resolved": "https://axags.jfrog.io/axags/api/npm/virtual-bcn-node/es6-promise/-/es6-promise-4.2.8.tgz",
-			"integrity": "sha1-TrIVlMlyvEBVPSduUQU5FD21Pgo="
-		},
-		"es6-promisify": {
-			"version": "5.0.0",
-			"resolved": "https://axags.jfrog.io/axags/api/npm/virtual-bcn-node/es6-promisify/-/es6-promisify-5.0.0.tgz",
-			"integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
-			"requires": {
-				"es6-promise": "^4.0.3"
-			}
-		},
 		"https-proxy-agent": {
-			"version": "3.0.1",
-			"resolved": "https://axags.jfrog.io/axags/api/npm/virtual-bcn-node/https-proxy-agent/-/https-proxy-agent-3.0.1.tgz",
-			"integrity": "sha1-uMKGQz6HYCMRsByOo0QT2Fakr4E=",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
+			"integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
 			"requires": {
-				"agent-base": "^4.3.0",
-				"debug": "^3.1.0"
+				"agent-base": "6",
+				"debug": "4"
 			}
 		},
 		"ms": {
 			"version": "2.1.2",
-			"resolved": "https://axags.jfrog.io/axags/api/npm/virtual-bcn-node/ms/-/ms-2.1.2.tgz",
-			"integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk="
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
 		}
 	}
 }

--- a/packages/request/package.json
+++ b/packages/request/package.json
@@ -25,7 +25,7 @@
     "test": "echo \"Error: run tests from root\" && exit 1"
   },
   "dependencies": {
-    "https-proxy-agent": "^3.0.1"
+    "https-proxy-agent": "^5.0.0"
   },
   "gitHead": "9769b29f1973d20a64d6a0f5e369e9c05c5526a8"
 }


### PR DESCRIPTION
Avoid request patching https://github.com/TooTallNate/node-agent-base/issues/38

# Pull Request Template

## PR Checklist

- [x] I have run `npm test` locally and all tests are passing.
- [ ] I have added/updated tests for any new behavior.
- [ ] If this is a significant change, an issue has already been created where the problem / solution was discussed: [N/A]

## PR Description

This bumps the version of `https-proxy-agent`. The usage of `https-proxy-agent` has nothing out of the ordinary, so this should not hurt compatibility.