### PR TITLE
fix: reduce edges now order edges before processing

### DIFF
--- a/packages/ner/src/reduce-edges.js
+++ b/packages/ner/src/reduce-edges.js
@@ -22,8 +22,18 @@
  */
 
 function runDiscard(srcEdge, srcOther, useMaxLength) {
-  const edge = srcEdge;
-  const other = srcOther;
+  let edge;
+  let other;
+  if (
+    srcEdge.accuracy > srcOther.accuracy ||
+    (srcEdge.accuracy === srcOther.accuracy && srcEdge.length > srcOther.length)
+  ) {
+    edge = srcEdge;
+    other = srcOther;
+  } else {
+    edge = srcOther;
+    other = srcEdge;
+  }
   if (other.start <= edge.end && other.end >= edge.start) {
     if (other.accuracy < edge.accuracy) {
       other.discarded = true;


### PR DESCRIPTION
# Pull Request Template

## PR Checklist

- [X] I have run `npm test` locally and all tests are passing.
- [ ] I have added/updated tests for any new behavior.
- [ ] If this is a significant change, an issue has already been created where the problem / solution was discussed: [N/A, or add link to issue here]

## PR Description
At discard edges the order or the edges now is taken into account. As the array of edges is not sorted from best to worst, then sorting 2 by 2 is the best option here.
It fixes https://github.com/axa-group/nlp.js/issues/460