### PR TITLE
feat: return nlp information in Directline API

### DIFF
--- a/packages/directline-connector/src/directline-controller.js
+++ b/packages/directline-connector/src/directline-controller.js
@@ -163,6 +163,18 @@ class DirectlineController {
               .then((nlpresult) => {
                 result.text =
                   nlpresult.answer || "Sorry, I didn't understand you";
+                if (activity.channelId === 'emulator') {
+                  result.nlp = {
+                    intent: nlpresult.intent,
+                    score: nlpresult.score,
+                    classifications: nlpresult.classifications,
+                    domain: nlpresult.domain,
+                    entities: nlpresult.entities,
+                    language: nlpresult.language,
+                    languageGuessed: nlpresult.languageGuessed,
+                    locale: nlpresult.locale,
+                  };
+                }
                 conversation.history.push(result);
                 resolve({
                   status: 200,


### PR DESCRIPTION
# Pull Request Template

## PR Checklist

- [X] I have run `npm test` locally and all tests are passing.
- [ ] I have added/updated tests for any new behavior.
- [ ] If this is a significant change, an issue has already been created where the problem / solution was discussed: [N/A, or add link to issue here]

## PR Description

When the channel is emulator, then return the NLP information in the Activitity of the Directline.