### PR TITLE
🐛 Fix bug for numeral features when exporting/importing

### DIFF
--- a/packages/api-auth-jwt/package-lock.json
+++ b/packages/api-auth-jwt/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "@nlpjs/database",
+  "name": "@nlpjs/api-auth-jwt",
   "version": "4.8.0",
   "lockfileVersion": 1,
   "requires": true,

--- a/packages/builtin-microsoft/package-lock.json
+++ b/packages/builtin-microsoft/package-lock.json
@@ -82,11 +82,6 @@
 				"@microsoft/recognizers-text-sequence": "~1.3.0"
 			}
 		},
-		"@nlpjs/core": {
-			"version": "4.6.0",
-			"resolved": "https://registry.npmjs.org/@nlpjs/core/-/core-4.6.0.tgz",
-			"integrity": "sha512-fz3YwFWbXVLUwat7bwwF1z76vxMFHLJ13BGPytkHN198cmD/N+AJ8RLnhjduAShv4ai9LH5xXK0cJS1HdHJFQg=="
-		},
 		"bignumber.js": {
 			"version": "7.2.1",
 			"resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-7.2.1.tgz",

--- a/packages/neural-worker/src/neural-network.js
+++ b/packages/neural-worker/src/neural-network.js
@@ -312,7 +312,13 @@ class NeuralNetwork extends Clonable {
         perceptronSettings: settings,
       };
     }
-    const features = Object.keys(this.inputLookup);
+    const features = Object.entries(this.inputLookup)
+      .sort((a, b) => {
+        return a[1] - b[1];
+      })
+      .map((entry) => {
+        return entry[0];
+      });
     const intents = Object.keys(this.outputLookup);
     const perceptrons = [];
     for (let i = 0; i < intents.length; i += 1) {
@@ -335,11 +341,11 @@ class NeuralNetwork extends Clonable {
     });
     if (json.features) {
       this.sizes = [json.features.length, json.intents.length];
-      const layer0 = {};
+      const inputLookup = {};
       for (let i = 0; i < json.features.length; i += 1) {
-        layer0[json.features[i]] = {};
+        inputLookup[json.features[i]] = i;
       }
-      this.inputLookup = toHash(layer0);
+      this.inputLookup = inputLookup;
       const layer1 = {};
       for (let i = 0; i < json.intents.length; i += 1) {
         const intent = json.intents[i];

--- a/packages/neural/src/neural-network.js
+++ b/packages/neural/src/neural-network.js
@@ -312,13 +312,11 @@ class NeuralNetwork extends Clonable {
     });
     if (json.features) {
       this.sizes = [json.features.length, json.intents.length];
-
       const inputLookup = {};
       for (let i = 0; i < json.features.length; i += 1) {
         inputLookup[json.features[i]] = i;
       }
       this.inputLookup = inputLookup;
-
       const layer1 = {};
       for (let i = 0; i < json.intents.length; i += 1) {
         const intent = json.intents[i];

--- a/packages/neural/src/neural-network.js
+++ b/packages/neural/src/neural-network.js
@@ -282,7 +282,15 @@ class NeuralNetwork extends Clonable {
         perceptronSettings: settings,
       };
     }
-    const features = Object.keys(this.inputLookup);
+
+    // sort features by value
+    const features = Object.entries(this.inputLookup)
+      .sort((a, b) => {
+        return a[1] - b[1];
+      })
+      .map((entry) => {
+        return entry[0];
+      });
     const intents = Object.keys(this.outputLookup);
     const perceptrons = [];
     for (let i = 0; i < intents.length; i += 1) {
@@ -305,11 +313,13 @@ class NeuralNetwork extends Clonable {
     });
     if (json.features) {
       this.sizes = [json.features.length, json.intents.length];
-      const layer0 = {};
+
+      const inputLookup = {};
       for (let i = 0; i < json.features.length; i += 1) {
-        layer0[json.features[i]] = {};
+        inputLookup[json.features[i]] = i;
       }
-      this.inputLookup = toHash(layer0);
+      this.inputLookup = inputLookup;
+
       const layer1 = {};
       for (let i = 0; i < json.intents.length; i += 1) {
         const intent = json.intents[i];

--- a/packages/neural/src/neural-network.js
+++ b/packages/neural/src/neural-network.js
@@ -283,7 +283,6 @@ class NeuralNetwork extends Clonable {
       };
     }
 
-    // sort features by value
     const features = Object.entries(this.inputLookup)
       .sort((a, b) => {
         return a[1] - b[1];


### PR DESCRIPTION
# Pull Request Template

## PR Checklist

- [x] I have run `npm test` locally and all tests are passing.
- [ ] I have added/updated tests for any new behavior.
- [ ] If this is a significant change, an issue has already been created where the problem / solution was discussed: [N/A, or add link to issue here]

## PR Description

Related issue #490
`import` and `export` did not work as expected for my model. After debugging for a bit, I realized that the order of features is incorrect when there are numeral features. \
The reason for that is, that `Object.keys` orders numbers first.

In `NeuralNetwork` (both packages) I've made the following changes:
1. `toJSON`: instead of using `Object.keys` to get the features, I sort the object's entries by it's value and then return it's key.
2. `fromJSON`: instead of using `toHash` which uses `Object.keys` under the hood, I iterate the features and directly set them. 

These changes guarantee that a numeral feature is at the correct position in `inputLookup`.

If you have any questions, just let me know.

PS: Thanks for the nice library!