### PR TITLE
feat: improve performance by cache and avoid ner if no entity is defined

### DIFF
--- a/packages/core/src/tokenizer.js
+++ b/packages/core/src/tokenizer.js
@@ -54,7 +54,37 @@ class Tokenizer {
   }
 
   tokenize(text, normalize) {
-    return this.innerTokenize(this.normalize(text, normalize));
+    let result;
+    if (this.cache) {
+      const now = new Date();
+      const diff = Math.abs(now.getTime() - this.cache.created) / 3600000;
+      if (diff > 1) {
+        this.cache = undefined;
+      }
+    }
+    if (!this.cache) {
+      this.cache = {
+        created: new Date().getTime(),
+        normalized: {},
+        nonNormalized: {},
+      };
+    } else {
+      if (normalize) {
+        result = this.cache.normalized[text];
+      } else {
+        result = this.cache.nonNormalized[text];
+      }
+      if (result) {
+        return result;
+      }
+    }
+    result = this.innerTokenize(this.normalize(text, normalize));
+    if (normalize) {
+      this.cache.normalized[text] = result;
+    } else {
+      this.cache.nonNormalized[text] = result;
+    }
+    return result;
   }
 
   async run(srcInput) {

--- a/packages/slot/src/slot-manager.js
+++ b/packages/slot/src/slot-manager.js
@@ -30,6 +30,7 @@ class SlotManager {
    */
   constructor() {
     this.intents = {};
+    this.isEmpty = true;
   }
 
   /**
@@ -64,6 +65,7 @@ class SlotManager {
    * @returns {Object} New slot instance.
    */
   addSlot(intent, entity, mandatory = false, questions) {
+    this.isEmpty = false;
     if (!this.intents[intent]) {
       this.intents[intent] = {};
     }


### PR DESCRIPTION
# Pull Request Template

## PR Checklist

- [X] I have run `npm test` locally and all tests are passing.
- [ ] I have added/updated tests for any new behavior.
- [ ] If this is a significant change, an issue has already been created where the problem / solution was discussed: [N/A, or add link to issue here]

## PR Description

Improve performance by:
- Use caches, mainly on the prepare method of nlu and tokenizers. Those caches are automatically cleaned to avoid being a memory leak.
- Sentiment analysis can be disabled in the NLP options.
- Optional Utterance and NER is not triggered if no entities where defined to intents (at the slot manager).