### PR TITLE
fix: await onHear on MSBF connector

### DIFF
--- a/packages/msbf-connector/src/msbf-connector.js
+++ b/packages/msbf-connector/src/msbf-connector.js
@@ -79,7 +79,7 @@ class MsbfConnector extends Clonable {
               msbfContext: context,
             };
             if (this.onHear) {
-              this.onHear(this, input);
+              await this.onHear(this, input);
             } else {
               const name = `${this.settings.tag}.hear`;
               const pipeline = this.container.getPipeline(name);


### PR DESCRIPTION
# Pull Request Template

## PR Checklist

- [X] I have run `npm test` locally and all tests are passing.
- [ ] I have added/updated tests for any new behavior.
- [ ] If this is a significant change, an issue has already been created where the problem / solution was discussed: [N/A, or add link to issue here]

## PR Description
onHear event of MSBF connector must be awaited