### PR TITLE
fix: cannot read property of undefined at ApiAuthJwt.register

### DIFF
--- a/packages/api-auth-jwt/src/api-auth-jwt.js
+++ b/packages/api-auth-jwt/src/api-auth-jwt.js
@@ -29,18 +29,20 @@ const getSettings = require('./default-settings');
 
 class ApiAuthJwt {
   register(container) {
-    const settings = getSettings(container);
-    const database = container.get('database');
-    const apiServer = container.get('api-server');
-    configurePassport(database, settings);
-    const plugin = passport.initialize();
-    apiServer.plugins.push(plugin);
-    const logger = container.get('logger');
-    container.register('auth', { ensureAuthenticated });
-    const router = apiServer.newRouter();
-    mountUser(router, container);
-    apiServer.routers.push(router);
-    logger.info('API Auth JWT plugin mounted');
+    process.nextTick(() => {
+      const settings = getSettings(container);
+      const database = container.get('database');
+      const apiServer = container.get('api-server');
+      configurePassport(database, settings);
+      const plugin = passport.initialize();
+      apiServer.plugins.push(plugin);
+      const logger = container.get('logger');
+      container.register('auth', { ensureAuthenticated });
+      const router = apiServer.newRouter();
+      mountUser(router, container);
+      apiServer.routers.push(router);
+      logger.info('API Auth JWT plugin mounted');
+    });
   }
 }
 

--- a/packages/api-auth-jwt/test/api-auth-jwt.test.js
+++ b/packages/api-auth-jwt/test/api-auth-jwt.test.js
@@ -42,18 +42,20 @@ function callWithReq(method, path, req, srcContainer) {
     const container = srcContainer || bootstrap();
     const apiAuthJwt = new ApiAuthJwt();
     apiAuthJwt.register(container);
-    const apiServer = container.get('api-server');
-    const res = new ResMock();
-    const callback = (err, result) => {
-      resolve({
-        container,
-        res,
-        err,
-        result,
-      });
-    };
-    res.callback = callback;
-    apiServer.call(method, path, req, res, callback);
+    process.nextTick(() => {
+      const apiServer = container.get('api-server');
+      const res = new ResMock();
+      const callback = (err, result) => {
+        resolve({
+          container,
+          res,
+          err,
+          result,
+        });
+      };
+      res.callback = callback;
+      apiServer.call(method, path, req, res, callback);
+    });
   });
 }
 


### PR DESCRIPTION
# Pull Request Template

## PR Checklist

- [x] I have run `npm test` locally and all tests are passing.
- [x] I have added/updated tests for any new behavior.
- [ ] If this is a significant change, an issue has already been created where the problem / solution was discussed: [N/A, or add link to issue here] __N/A -- I think/ hope?!__

## PR Description

<!-- Describe Your PR Here! -->

Hi,

When I create and run a test Bot using the `ApiAuthJwt` plugin, I get the following error:

```sh
> node index.js

...
(node:19371) UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'plugins' of undefined
    at ApiAuthJwt.register (/Users/nXXX/workspace/nlpjs-auth-test/node_modules/@nlpjs/api-auth-jwt/src/api-auth-jwt.js:37:15)
    at Container.use (/Users/nXXX/workspace/nlpjs-auth-test/node_modules/@nlpjs/core/src/container.js:346:16)
    at containerBootstrap (/Users/nXXX/workspace/nlpjs-auth-test/node_modules/@nlpjs/core-loader/src/container-bootstrap.js:233:20)
    at Dock.createContainer (/Users/nXXX/workspace/nlpjs-auth-test/node_modules/@nlpjs/core-loader/src/dock.js:68:25)
    at Dock.terraform (/Users/nXXX/workspace/nlpjs-auth-test/node_modules/@nlpjs/core-loader/src/dock.js:113:41)
    at Dock.start (/Users/nXXX/workspace/nlpjs-auth-test/node_modules/@nlpjs/core-loader/src/dock.js:123:17)
    at dockStart (/Users/nXXX/workspace/nlpjs-auth-test/node_modules/@nlpjs/core-loader/src/index.js:59:14)
    at /Users/nXXX/workspace/nlpjs-auth-test/index.js:12:22
    at Object.<anonymous> (/Users/nXXX/workspace/nlpjs-auth-test/index.js:26:3)
    at Module._compile (internal/modules/cjs/loader.js:1201:30)
```

The line in question (`37`) is :~

```js
apiServer.plugins.push(plugin);
```

Using `process.nextTick()` ensures that `apiServer` has been correctly constructed and registered, before `apiServer.plugins.push(..)` is called.

There is a corresponding use of `process.nextTick()` in the unit tests to ensure they run successfully.

I hope this is a useful fix!

Yours,

Nick