### PR TITLE
feat: min length before stemming a czech word

### DIFF
--- a/packages/lang-cs/src/stemmer-cs.js
+++ b/packages/lang-cs/src/stemmer-cs.js
@@ -402,6 +402,9 @@ class StemmerCs extends BaseStemmer {
     return true;
   }
   innerStem() {
+    if (this.current.length <= 4) {
+      return true;
+    }
     let v_1;
     v_1 = this.cursor;
     lab0: do {


### PR DESCRIPTION
# Pull Request Template

## PR Checklist

- [X] I have run `npm test` locally and all tests are passing.
- [X] I have added/updated tests for any new behavior.
- [X] If this is a significant change, an issue has already been created where the problem / solution was discussed: [N/A, or add link to issue here]

## PR Description

A czech word should be at least 5 chars length to be stemmed