### PR TITLE
fix: StemmerTr was overriding the wrong method

### DIFF
--- a/packages/lang-tr/src/stemmer-tr.js
+++ b/packages/lang-tr/src/stemmer-tr.js
@@ -3049,7 +3049,7 @@ class StemmerTr extends BaseStemmer {
     return true;
   }
 
-  stem() {
+  innerStem() {
     let v_1;
     let v_2;
     // (, line 464

--- a/packages/lang-tr/test/stemmer-tr.test.js
+++ b/packages/lang-tr/test/stemmer-tr.test.js
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) AXA Group Operations Spain S.A.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+const { NormalizerTr, TokenizerTr, StemmerTr } = require('../src');
+
+const normalizer = new NormalizerTr();
+const tokenizer = new TokenizerTr();
+const stemmer = new StemmerTr();
+
+describe('Stemmer', () => {
+  describe('Constructor', () => {
+    test('It should create a new instance', () => {
+      const instance = new StemmerTr();
+      expect(instance).toBeDefined();
+    });
+  });
+
+  describe('Stem', () => {
+    test('Should stem "Şirketiniz ne geliştiriyor?"', () => {
+      const input = 'Şirketiniz ne geliştiriyor?';
+      const expected = ['sirket', 'ne', 'gelistiriyor'];
+      const tokens = tokenizer.tokenize(normalizer.normalize(input));
+      const actual = stemmer.stem(tokens);
+      expect(actual).toEqual(expected);
+    });
+  });
+});


### PR DESCRIPTION
# Pull Request Template

## PR Checklist

- [x] I have run `npm test` locally and all tests are passing.
- [x] I have added/updated tests for any new behavior.
- [N/A] If this is a significant change, an issue has already been created where the problem / solution was discussed: [N/A, or add link to issue here]

## PR Description

Turkish Stemmer was not working because it was overriding "stem" instead of "innerStem"
