### PR TITLE
fix: japanese stemmer now read correctly the dictionary

### DIFF
--- a/packages/lang-ja/src/stemmer-ja.js
+++ b/packages/lang-ja/src/stemmer-ja.js
@@ -21,6 +21,7 @@
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
+const fs = require('fs');
 const path = require('path');
 const { BaseStemmer } = require('@nlpjs/core');
 
@@ -49,7 +50,16 @@ class StemmerJa extends BaseStemmer {
       if (StemmerJa.tokenizer) {
         resolve();
       } else {
-        const dicPath = path.join(__dirname, '../node_modules/kuromoji/dict');
+        let dicPath = path.join(__dirname, '../node_modules/kuromoji/dict');
+        if (!fs.existsSync(dicPath)) {
+          dicPath = path.join(
+            __dirname,
+            '../../../../node_modules/kuromoji/dict'
+          );
+          if (!fs.existsSync(dicPath)) {
+            dicPath = './node_modules/kuromoji/dict';
+          }
+        }
         kuromoji.builder({ dicPath }).build((err, tokenizer) => {
           if (err) {
             reject(err);

--- a/packages/nlp/src/nlp.js
+++ b/packages/nlp/src/nlp.js
@@ -522,6 +522,11 @@ class Nlp extends Clonable {
       output.entities = [];
       output.sourceEntities = [];
     }
+    const stemmer = this.container.get(`stemmer-${output.locale}`);
+    if (stemmer && stemmer.lastFill) {
+      stemmer.lastFill(output);
+      console.log(output);
+    }
     const answers = await this.nlgManager.run({ ...output });
     output.answers = answers.answers;
     output.answer = answers.answer;


### PR DESCRIPTION
# Pull Request Template

## PR Checklist

- [X] I have run `npm test` locally and all tests are passing.
- [X] I have added/updated tests for any new behavior.
- [X] If this is a significant change, an issue has already been created where the problem / solution was discussed: [N/A, or add link to issue here]

## PR Description
- Fix japanese stemmer to load dictionaries
- Add post-fill from stemmers in NLP