### PR TITLE
fix: Evaluator falsy values do not process correctly texts

### DIFF
--- a/packages/evaluator/src/compile.js
+++ b/packages/evaluator/src/compile.js
@@ -40,7 +40,9 @@ function processString(str, context) {
   const matches = dictionary[str];
   return matches.reduce((p, c) => {
     const solution = evaluator.evaluate(c.substr(2, c.length - 4), context);
-    return solution ? p.replace(c, solution) : p;
+    return solution !== null && solution !== undefined
+      ? p.replace(c, solution)
+      : p;
   }, str);
 }
 


### PR DESCRIPTION
# Pull Request Template

## PR Checklist

- [X] I have run `npm test` locally and all tests are passing.
- [X] I have added/updated tests for any new behavior.
- [X] If this is a significant change, an issue has already been created where the problem / solution was discussed: [N/A, or add link to issue here]

## PR Description
When the evaluator have variables evaluated to falsy (empty string, 0,...) then the variable was not replaced.