### PR TITLE
feaat: sentiment dictionaries can be non stemmed

### DIFF
--- a/packages/lang-bn/src/sentiment/sentiment_bn.js
+++ b/packages/lang-bn/src/sentiment/sentiment_bn.js
@@ -29,4 +29,5 @@ module.exports = {
   pattern: undefined,
   senticon: undefined,
   negations,
+  stemmed: true,
 };

--- a/packages/lang-ca/src/sentiment/sentiment_ca.js
+++ b/packages/lang-ca/src/sentiment/sentiment_ca.js
@@ -29,4 +29,5 @@ module.exports = {
   pattern: undefined,
   senticon,
   negations,
+  stemmed: true,
 };

--- a/packages/lang-da/src/sentiment/sentiment_da.js
+++ b/packages/lang-da/src/sentiment/sentiment_da.js
@@ -29,4 +29,5 @@ module.exports = {
   pattern: undefined,
   senticon: undefined,
   negations,
+  stemmed: true,
 };

--- a/packages/lang-de/src/sentiment/sentiment_de.js
+++ b/packages/lang-de/src/sentiment/sentiment_de.js
@@ -29,4 +29,5 @@ module.exports = {
   pattern: undefined,
   senticon,
   negations,
+  stemmed: true,
 };

--- a/packages/lang-en/src/sentiment/sentiment_en.js
+++ b/packages/lang-en/src/sentiment/sentiment_en.js
@@ -27,4 +27,5 @@ const negations = require('./negations_en.json');
 module.exports = {
   senticon,
   negations,
+  stemmed: true,
 };

--- a/packages/lang-es/src/sentiment/sentiment_es.js
+++ b/packages/lang-es/src/sentiment/sentiment_es.js
@@ -30,4 +30,5 @@ module.exports = {
   pattern: undefined,
   senticon,
   negations,
+  stemmed: true,
 };

--- a/packages/lang-eu/src/sentiment/sentiment_eu.js
+++ b/packages/lang-eu/src/sentiment/sentiment_eu.js
@@ -29,4 +29,5 @@ module.exports = {
   pattern: undefined,
   senticon,
   negations,
+  stemmed: true,
 };

--- a/packages/lang-fi/src/sentiment/sentiment_fi.js
+++ b/packages/lang-fi/src/sentiment/sentiment_fi.js
@@ -29,4 +29,5 @@ module.exports = {
   pattern: undefined,
   senticon: undefined,
   negations,
+  stemmed: true,
 };

--- a/packages/lang-fr/src/sentiment/sentiment_fr.js
+++ b/packages/lang-fr/src/sentiment/sentiment_fr.js
@@ -29,4 +29,5 @@ module.exports = {
   pattern,
   senticon: undefined,
   negations,
+  stemmed: true,
 };

--- a/packages/lang-gl/src/sentiment/sentiment_gl.js
+++ b/packages/lang-gl/src/sentiment/sentiment_gl.js
@@ -29,4 +29,5 @@ module.exports = {
   pattern: undefined,
   senticon,
   negations,
+  stemmed: true,
 };

--- a/packages/lang-it/src/sentiment/sentiment_it.js
+++ b/packages/lang-it/src/sentiment/sentiment_it.js
@@ -29,4 +29,5 @@ module.exports = {
   pattern,
   senticon: undefined,
   negations,
+  stemmed: true,
 };

--- a/packages/lang-nl/src/sentiment/sentiment_nl.js
+++ b/packages/lang-nl/src/sentiment/sentiment_nl.js
@@ -29,4 +29,5 @@ module.exports = {
   pattern,
   senticon: undefined,
   negations,
+  stemmed: true,
 };

--- a/packages/lang-pt/src/sentiment/sentiment_pt.js
+++ b/packages/lang-pt/src/sentiment/sentiment_pt.js
@@ -29,4 +29,5 @@ module.exports = {
   pattern: undefined,
   senticon: undefined,
   negations,
+  stemmed: true,
 };

--- a/packages/lang-ru/src/sentiment/sentiment_ru.js
+++ b/packages/lang-ru/src/sentiment/sentiment_ru.js
@@ -29,4 +29,5 @@ module.exports = {
   pattern: undefined,
   senticon: undefined,
   negations,
+  stemmed: true,
 };


### PR DESCRIPTION
# Pull Request Template

## PR Checklist

- [X] I have run `npm test` locally and all tests are passing.
- [ ] I have added/updated tests for any new behavior.
- [ ] If this is a significant change, an issue has already been created where the problem / solution was discussed: [N/A, or add link to issue here]

## PR Description

Sentiment analysys can use non stemmed dictionaries