### PR TITLE
feat: mongodb adapter now is a plugin that registers as database

### DIFF
--- a/packages/core-loader/src/plugin-information.json
+++ b/packages/core-loader/src/plugin-information.json
@@ -52,6 +52,8 @@
   "LangUk": { "className": "LangUk", "path": "@nlpjs/lang-uk" },
   "LangZh": { "className": "LangZh", "path": "@nlpjs/lang-zh" },
   "logger": { "className": "logger", "path": "@nlpjs/logger" },
+  "Mongodb": { "className": "MongodbAdapter", "path": "@nlpjs/mongodb-adapter" },
+  "MongodbAdapter": { "className": "MongodbAdapter", "path": "@nlpjs/mongodb-adapter" },
   "MsbfConnector": { "className": "MsbfConnector", "path": "@nlpjs/msbf-connector" },
   "Nlp": { "className": "Nlp", "path": "@nlpjs/nlp" },
   "NluLuis": { "className": "NluLuis", "path": "@nlpjs/nlu-luis" },

--- a/packages/mongodb-adapter/src/mongodb-adapter.js
+++ b/packages/mongodb-adapter/src/mongodb-adapter.js
@@ -51,6 +51,17 @@ class MongodbAdapter extends Clonable {
       useNewUrlParser: true,
       useUnifiedTopology: true,
     });
+    this.registerDefault();
+  }
+
+  registerDefault() {
+    const database = this.container
+      ? this.container.get('database')
+      : undefined;
+    if (database) {
+      database.registerAdapter('mongodb', this);
+      database.defaultAdapter = 'mongodb';
+    }
   }
 
   connect() {


### PR DESCRIPTION
# Pull Request Template

## PR Checklist

- [X] I have run `npm test` locally and all tests are passing.
- [ ] I have added/updated tests for any new behavior.
- [ ] If this is a significant change, an issue has already been created where the problem / solution was discussed: [N/A, or add link to issue here]

## PR Description
Register MongodbAdapter as plugin