### PR TITLE
fix: prevents the sourceText from being improperly converted to lower case

### DIFF
--- a/packages/ner/src/extractor-enum.js
+++ b/packages/ner/src/extractor-enum.js
@@ -230,7 +230,7 @@ class ExtractorEnum {
               entity: rule.name,
               type: rule.type,
               option: subrule[k].option,
-              sourceText: str,
+              sourceText: srcText,
               utteranceText: srcText.substring(
                 wordPositions[i].start,
                 wordPositions[j].end + 1


### PR DESCRIPTION
# Pull Request Template

## PR Checklist

- [x] I have run `npm test` locally and all tests are passing.

## PR Description

We're only returning the original `sourceText` instead translate it to lower case ;)

Closes #625