### PR TITLE
fix: default stemmed for sentiment dictionaries must be false

### DIFF
--- a/examples/13-languages/corpora/corpus-en.json
+++ b/examples/13-languages/corpora/corpus-en.json
@@ -481,7 +481,7 @@
         "can you assist me"
       ],
       "tests": [
-        "?",
+        "assist me",
         "please help me",
         "perhaps you can assist me",
         "someone can help me?",

--- a/packages/sentiment/src/sentiment-analyzer.js
+++ b/packages/sentiment/src/sentiment-analyzer.js
@@ -108,7 +108,8 @@ class SentimentAnalyzer extends Clonable {
       type,
       dictionary: dictionaries[type],
       negations: dictionaries.negations.words,
-      stemmed: dictionaries.stemmed === undefined ? true : dictionaries.stemmed,
+      stemmed:
+        dictionaries.stemmed === undefined ? false : dictionaries.stemmed,
     };
     return input;
   }


### PR DESCRIPTION
# Pull Request Template

## PR Checklist

- [X] I have run `npm test` locally and all tests are passing.
- [ ] I have added/updated tests for any new behavior.
- [ ] If this is a significant change, an issue has already been created where the problem / solution was discussed: [N/A, or add link to issue here]

## PR Description
Default "stemmed" for sentiment dictionaries must be false