### PR TITLE
fix: trim match when word is at position 0

### DIFF
--- a/examples/13-languages/measure-corpus.js
+++ b/examples/13-languages/measure-corpus.js
@@ -51,6 +51,8 @@ async function measureCorpus(corpus, plugins) {
       let result = await nlp.process(test);
       if (result.intent === item.intent) {
         goodNoThreshold += 1;
+      } else {
+        console.log(`${result.intent} ${item.intent} ${test}`);
       }
       nlp.settings.threshold = 0.5;
       result = await nlp.process(test);

--- a/packages/ner/src/extractor-trim.js
+++ b/packages/ner/src/extractor-trim.js
@@ -252,6 +252,12 @@ class ExtractorTrim {
         ? condition.words[i]
         : ` ${condition.words[i]}`;
       const wordPositions = this.findWord(utterance, word);
+      if (!condition.options.noSpaces) {
+        const wordPositions2 = this.findWord(utterance, condition.words[i]);
+        if (wordPositions2.length > 0 && wordPositions2[0].start === 0) {
+          wordPositions.unshift(wordPositions2[0]);
+        }
+      }
       if (wordPositions.length > 0) {
         result.push(...this.getResults(utterance, wordPositions, type, name));
       }

--- a/packages/ner/test/extractor-trim.test.js
+++ b/packages/ner/test/extractor-trim.test.js
@@ -208,5 +208,28 @@ describe('Extractor Trim', () => {
         },
       ]);
     });
+
+    test('It should be able to retrieve at start of utterance', async () => {
+      const ner = new Ner();
+      ner.addAfterLastCondition('en', 'entity', 'from');
+      const input = {
+        text: 'from Barcelona to Madrid',
+        locale: 'en',
+      };
+      const actual = await ner.process(input);
+      expect(actual.entities).toEqual([
+        {
+          type: 'trim',
+          subtype: 'afterLast',
+          start: 5,
+          end: 23,
+          len: 19,
+          accuracy: 0.99,
+          sourceText: 'Barcelona to Madrid',
+          utteranceText: 'Barcelona to Madrid',
+          entity: 'entity',
+        },
+      ]);
+    });
   });
 });


### PR DESCRIPTION
# Pull Request Template

## PR Checklist

- [X] I have run `npm test` locally and all tests are passing.
- [X] I have added/updated tests for any new behavior.
- [ ] If this is a significant change, an issue has already been created where the problem / solution was discussed: [N/A, or add link to issue here]

## PR Description
Fix trim ner when word match at position 0