### PR TITLE
fix: memory adapter conditionKeys check length is 0

### DIFF
--- a/packages/database/src/memory-adapter.js
+++ b/packages/database/src/memory-adapter.js
@@ -142,7 +142,7 @@ class MemorydbAdapter extends Clonable {
     for (let i = 0; i < keys.length; i += 1) {
       const item = collection[keys[i]];
       if (
-        conditionKeys === 0 ||
+        conditionKeys.lenght === 0 ||
         MemorydbAdapter.match(item, condition || {}, conditionKeys)
       ) {
         if (pendingOffset > 0) {


### PR DESCRIPTION
# Pull Request Template

## PR Checklist

- [X] I have run `npm test` locally and all tests are passing.
- [ ] I have added/updated tests for any new behavior.
- [ ] If this is a significant change, an issue has already been created where the problem / solution was discussed: [N/A, or add link to issue here]

## PR Description
check if length of conditionKeys is 0.