### PR TITLE
multiple enum,regex,trim rules per entity

### DIFF
--- a/packages/builtin-compromise/test/compromise.test.js
+++ b/packages/builtin-compromise/test/compromise.test.js
@@ -47,7 +47,7 @@ describe('Compromise Integration', () => {
       const expected = 'en_US';
       expect(actual).toEqual(expected);
     });
-    
+
     test('From known culture', () => {
       const actual = BuiltinCompromise.getCulture('ja');
       const expected = 'ja_JP';
@@ -214,7 +214,6 @@ describe('Compromise Integration', () => {
       expect(actual.edges).toEqual(expected);
     });
 
-
     test('Compromise  English Time', async () => {
       const actual = await extract('en', '12/12/2019 at 9am');
 
@@ -235,32 +234,12 @@ describe('Compromise Integration', () => {
       expect(actual.edges).toEqual(expected);
     });
 
-    test('Compromise  English Date 2', async () => {
-      const actual = await extract('en', 'Next Friday');
-
-      const expected = [
-        {
-          entity: 'date',
-          start: 0,
-          end: 10,
-          len: 11,
-          accuracy: 0.95,
-          sourceText: 'Next Friday',
-          utteranceText: 'Next Friday',
-          resolution: {
-            value: '2020-12-04T00:00:00.000Z',
-          },
-        },
-      ];
-      expect(actual.edges).toEqual(expected);
-    });
-
     test('Compromise  Various', async () => {
       const actual = await extract(
         'en',
         'Its amazing #checkitout  I am moving to California to work at Google with Joe Jimson'
       );
-      
+
       const expected = [
         {
           start: 12,

--- a/packages/ner/src/extractor-enum.js
+++ b/packages/ner/src/extractor-enum.js
@@ -182,7 +182,7 @@ class ExtractorEnum {
     if (!allRules) {
       return [];
     }
-    return allRules.filter((x) => x.type === 'enum');
+    return allRules;
   }
 
   normalize(str) {
@@ -260,25 +260,27 @@ class ExtractorEnum {
     } else {
       for (let i = 0; i < rule.rules.length; i += 1) {
         const current = rule.rules[i];
-        for (let j = 0; j < current.texts.length; j += 1) {
-          const newEdges = this.getBestSubstringList(
-            text,
-            current.texts[j],
-            words,
-            current.threshold || threshold
-          );
-          for (let k = 0; k < newEdges.length; k += 1) {
-            edges.push({
-              ...newEdges[k],
-              entity: rule.name,
-              type: rule.type,
-              option: rule.rules[i].option,
-              sourceText: current.texts[j],
-              utteranceText: text.substring(
-                newEdges[k].start,
-                newEdges[k].end + 1
-              ),
-            });
+        if (current && current.option && Array.isArray(current.texts)) {
+          for (let j = 0; j < current.texts.length; j += 1) {
+            const newEdges = this.getBestSubstringList(
+              text,
+              current.texts[j],
+              words,
+              current.threshold || threshold
+            );
+            for (let k = 0; k < newEdges.length; k += 1) {
+              edges.push({
+                ...newEdges[k],
+                entity: rule.name,
+                type: rule.type,
+                option: rule.rules[i].option,
+                sourceText: current.texts[j],
+                utteranceText: text.substring(
+                  newEdges[k].start,
+                  newEdges[k].end + 1
+                ),
+              });
+            }
           }
         }
       }

--- a/packages/ner/src/extractor-regex.js
+++ b/packages/ner/src/extractor-regex.js
@@ -35,14 +35,14 @@ class ExtractorRegex {
     if (!allRules) {
       return [];
     }
-    return allRules.filter((x) => x.type === 'regex');
+    return allRules;
   }
 
   getMatchs(utterance, regex) {
     const result = [];
     let matchFound;
     do {
-      const match = regex.exec(utterance);
+      const match = (regex instanceof RegExp) ? regex.exec(utterance) : null;
       if (match) {
         result.push({
           start: match.index,

--- a/packages/ner/src/extractor-trim.js
+++ b/packages/ner/src/extractor-trim.js
@@ -247,19 +247,21 @@ class ExtractorTrim {
 
   match(utterance, condition, type, name) {
     const result = [];
-    for (let i = 0; i < condition.words.length; i += 1) {
-      const word = condition.options.noSpaces
-        ? condition.words[i]
-        : ` ${condition.words[i]}`;
-      const wordPositions = this.findWord(utterance, word);
-      if (!condition.options.noSpaces) {
-        const wordPositions2 = this.findWord(utterance, condition.words[i]);
-        if (wordPositions2.length > 0 && wordPositions2[0].start === 0) {
-          wordPositions.unshift(wordPositions2[0]);
+    if (condition && Array.isArray(condition.words)) {
+      for (let i = 0; i < condition.words.length; i += 1) {
+        const word = condition.options.noSpaces
+          ? condition.words[i]
+          : ` ${condition.words[i]}`;
+        const wordPositions = this.findWord(utterance, word);
+        if (!condition.options.noSpaces) {
+          const wordPositions2 = this.findWord(utterance, condition.words[i]);
+          if (wordPositions2.length > 0 && wordPositions2[0].start === 0) {
+            wordPositions.unshift(wordPositions2[0]);
+          }
         }
-      }
-      if (wordPositions.length > 0) {
-        result.push(...this.getResults(utterance, wordPositions, type, name));
+        if (wordPositions.length > 0) {
+          result.push(...this.getResults(utterance, wordPositions, type, name));
+        }
       }
     }
     const filteredResult = [];
@@ -276,7 +278,7 @@ class ExtractorTrim {
     if (!allRules) {
       return [];
     }
-    return allRules.filter((x) => x.type === 'trim');
+    return allRules;
   }
 
   extractFromRule(utterance, rule) {

--- a/packages/nlp/src/nlp.js
+++ b/packages/nlp/src/nlp.js
@@ -337,10 +337,7 @@ class Nlp extends Clonable {
       const entityName = keys[i];
       let entity = entities[entityName];
       if (typeof entity === 'string') {
-        entity = { regex: entity };
-      }
-      if (!entity.type) {
-        entity.type = entity.regex ? 'regex' : 'text';
+        entity = { regex: [entity] };
       }
       let finalLocale = entity.locale;
       if (!finalLocale) {
@@ -349,19 +346,36 @@ class Nlp extends Clonable {
       if (typeof finalLocale === 'string') {
         finalLocale = finalLocale.slice(0, 2);
       }
-      if (entity.type === 'text') {
-        const options = entity.options || {};
-        const optionNames = Object.keys(options);
+      if (entity.options) {
+        const optionNames = Object.keys(entity.options);
         for (let j = 0; j < optionNames.length; j += 1) {
           this.addNerRuleOptionTexts(
             finalLocale,
             entityName,
             optionNames[j],
-            options[optionNames[j]]
+            entity.options[optionNames[j]]
           );
         }
-      } else if (entity.type === 'regex') {
-        this.addNerRegexRule(finalLocale, entityName, entity.regex);
+      }
+      if (entity.regex) {
+        if (Array.isArray(entity.regex)) {
+          for (let j = 0; j < entity.regex.length; j += 1) {
+            this.addNerRegexRule(finalLocale, entityName, entity.regex[j]);
+          }
+        } else if (typeof entity.regex === 'string' && entity.regex.trim()) {
+          this.addNerRegexRule(finalLocale, entityName, entity.regex);
+        }
+      }
+      if (entity.trim) {
+        for (let j = 0; j < entity.trim.length; j += 1) {
+          this.addNerPositionCondition(
+            finalLocale,
+            entityName,
+            entity.trim[j].position,
+            entity.trim[j].words,
+            entity.trim[j].opts
+          );
+        }
       }
     }
   }


### PR DESCRIPTION
# Pull Request Template
I would like to be able to use the corpus file format to import entities that use a combination of options, regular expressions and trims.

I suggest to alter the addEntities function to allow importing an entity with the following format
 "entities": {
    "chessMoveFrom": {
       options:['a','b'],
       regex: ['[\d]'] ,
       trim: [{position:'between',words:['from','to'],options:{caseInsensitive:true}]
    }
----------------------------------------------------------
In the process of testing the changes I made to addEntities I noticed that while an array of disparate rule types can be added under a single entity key, the extractors were throwing errors when presented with rules that didn't match the expected structure. 

Where disparate rule types are added to a single entity, the type is set appropriately for the first rule.
When the extractors try to filter rules based on type, and some of the rules do not match the expected structure errors occur.

This pull request includes changes to the extractors to
- do existence checks before assuming the structure of rules when iterating
-  remove filters in getRules

---------------------------------
Currently the nlp.addEntities function allows for 
- an options array 

```
 "entities": {
    "chessMoveFrom": {
      "options": {
        "a2": [
          "a2",  // synonyms
          "a2",
          "a 2"
        ],
```

OR
- a string which is treated as a regex
"entities": {
    "chessMoveFrom": '[a-h1-8]'
    

To maintain backward compatibility with string as regex I'd suggest changes similar to 
   
=======================
Updated for multiple sources per entity
=======================
function addEntities(nlp,entities, locale) {
        const keys = Object.keys(entities);
        for (let i = 0; i < keys.length; i += 1) {
          const entityName = keys[i];
          let entity = entities[entityName];
          if (typeof entity === 'string') {
            entity = { regex: [entity] };
          }
          let finalLocale = entity.locale;
          if (!finalLocale) {
            finalLocale = locale || 'en';
          }
          if (typeof finalLocale === 'string') {
            finalLocale = finalLocale.slice(0, 2);
          }
          if (entity.options) {
            const optionNames = Object.keys(entity.options);
            for (let j = 0; j < optionNames.length; j += 1) {
              nlp.addNerRuleOptionTexts(
                finalLocale,
                entityName,
                optionNames[j],
                entity.options[optionNames[j]]
              );
            }
          }
          if (entity.regex) {
                if (Array.isArray(entity.regex) {
                  for (let j = 0; j < entity.regex.length; j += 1) {
                      nlp.addNerRegexRule(finalLocale, entityName, entity.regex[j]);
                  }
                } else if (typeof entity.regex === "string") {
                    nlp.addNerRegexRule(finalLocale, entityName, entity.regex);
                } 
          }
          if (entity.trim) {
              for (let j = 0; j < entity.trim.length; j += 1) {
                  nlp.addNerPositionCondition(finalLocale, entityName, entity.trim[j].position, entity.trim[j].words, entity.trim[j].opts)
              }
          }
        }
    }


**Describe alternatives you've considered**

Because nlp.addEntities is used by nlp.addCorpus as the primary pathway for importing models, I cannot see another way of effecting the change.

**Additional context**

I would like to be able to import and export NLP.JS format files from https://opennludata.org

I've added import and export features for NLP.JS based on my proposal.

Additionally I've added some logic to map the RASA based rules/stories format to intent answers in nlp.js.
Where nlp.js provides answers, create utterances and rules necessary to map the intents to the utterances.
Where intent and utterances names can be split by "/" (or "." on import), RASA style response selector mapping applies.
When exporting, the reverse of using rules to bind utterances as answers is applied.

contextData is also imported and used when replacing markers in response templates.

It would be neat for nlp.js to have a supported standard export format to support data conversion tooling. 
I am unclear if .dlg is the future which concerns me seeing logic rules embedded in templates.

It also strikes me as useful to draw a line between the training data required for NLP and the training data/code that is required for routing/dialog management.
Many users will be interested in replacing an existing online NLU only service.

I'm very interested to see where you're going with your bot framework.
So far context/rules based.

I've mentioned voicedialogjs as my answer to RASA routing in a browser. Supports rules and stories(machine learning)  and forms(slot filling) and response selectors (machine learning) as well as responses(cards),  actions and apis to implement dynamic output.

Because I'm moving files to/from a browser, I've been running with a single json file to jam the whole lot together (including base64 media) with top level keys including

for nlp

- intents
- entities
- utterances (responses)


and for routing 

- stories
- rules
- forms
- actions
- apis

Thinking about these last five as constructs in modeling a dialog, I think there is also a place for goals which mimic forms but last until explicitly closed and allow for multiple concurrent active forms. Perhaps multiple concurrent forms could provide what is necessary.

## PR Checklist

- [X ] I have run `npm test` locally and all tests are passing.
- [X ] I have added/updated tests for any new behavior.
- [NA ] If this is a significant change, an issue has already been created where the problem / solution was discussed: [N/A, or add link to issue here]

## PR Description

<!-- Describe Your PR Here! -->