### PR TITLE
fix: avoid log(0) in deviation

### DIFF
--- a/packages/utils/src/is-gibberish.js
+++ b/packages/utils/src/is-gibberish.js
@@ -73,7 +73,8 @@ function getDeviation(value, lower, upper) {
     if (logDelta === 0) {
       return 1;
     }
-    return Math.log(Math.min(0, 1.5 - upper)) / logDelta;
+    const max = (upper > 1 ? 1.5 : 1) - upper;
+    return Math.log(max) / logDelta;
   }
   return 0;
 }

--- a/packages/utils/test/gibberish.test.js
+++ b/packages/utils/test/gibberish.test.js
@@ -9,6 +9,7 @@ describe('Gibberish', () => {
       expect(isGibberish('goodbye')).toBeFalsy();
       expect(isGibberish('sure')).toBeFalsy();
       expect(isGibberish('very much')).toBeFalsy();
+      expect(isGibberish('it feels so good')).toBeFalsy();
     });
     test('Should return true for gibberish sentences', () => {
       expect(isGibberish('zxcvwerjasc')).toBeTruthy();


### PR DESCRIPTION
# Pull Request Template

## PR Checklist

- [X] I have run `npm test` locally and all tests are passing.
- [X] I have added/updated tests for any new behavior.
- [X] If this is a significant change, an issue has already been created where the problem / solution was discussed: [N/A, or add link to issue here]

## PR Description

Avoid Log(0) in deviation calculation of gibberish score