### PR TITLE
feat: add way to handle cases when dialog doesnt exist

### DIFF
--- a/packages/bot/src/bot.js
+++ b/packages/bot/src/bot.js
@@ -181,7 +181,8 @@ class Bot extends Clonable {
             session.restartDialog(context);
             break;
           case 'beginDialog':
-            const dialog = `${action.dialog.startsWith('/') ? '' : `/`}${action.dialog}`;
+            const dialog = (action.dialog.startsWith('/') ? '' : '/') + action.dialog;
+
             if (this.dialogManager.existsDialog(dialog)) {
               session.beginDialog(context, dialog);
             } else {

--- a/packages/bot/src/bot.js
+++ b/packages/bot/src/bot.js
@@ -152,7 +152,7 @@ class Bot extends Clonable {
 
   async executeAction(session, context, action) {
     if (typeof action === 'string') {
-      if (action.startsWith('/')) {
+      if (action.startsWith('/') && this.dialogManager.existsDialog(action)) {
         session.beginDialog(context, action);
       } else {
         await session.say(action, context);
@@ -181,12 +181,12 @@ class Bot extends Clonable {
             session.restartDialog(context);
             break;
           case 'beginDialog':
-            session.beginDialog(
-              context,
-              action.dialog.startsWith('/')
-                ? action.dialog
-                : `/${action.dialog}`
-            );
+            const dialog = `${action.dialog.startsWith('/') ? '' : `/`}${action.dialog}`;
+            if (this.dialogManager.existsDialog(dialog)) {
+              session.beginDialog(context, dialog);
+            } else {
+              await session.say(dialog);
+            }
             break;
           case 'ask':
             context.isWaitingInput = true;
@@ -201,7 +201,7 @@ class Bot extends Clonable {
                 context
               );
               if (result.answer) {
-                if (result.answer.startsWith('/')) {
+                if (result.answer.startsWith('/') && this.dialogManager.existsDialog(result.answer)) {
                   session.beginDialog(context, result.answer);
                 } else {
                   await session.say(result.answer);

--- a/packages/bot/src/bot.js
+++ b/packages/bot/src/bot.js
@@ -166,7 +166,9 @@ class Bot extends Clonable {
         );
       }
       if (shouldContinue) {
+        const dialog = (action.dialog && action.dialog.startsWith('/') ? '' : '/') + action.dialog;
         let fn;
+
         switch (action.command) {
           case 'say':
             await session.say(action.text, context);
@@ -181,8 +183,6 @@ class Bot extends Clonable {
             session.restartDialog(context);
             break;
           case 'beginDialog':
-            const dialog = (action.dialog.startsWith('/') ? '' : '/') + action.dialog;
-
             if (this.dialogManager.existsDialog(dialog)) {
               session.beginDialog(context, dialog);
             } else {

--- a/packages/bot/src/dialog-manager.js
+++ b/packages/bot/src/dialog-manager.js
@@ -123,6 +123,10 @@ class DialogManager extends Clonable {
     }
     this.beginDialog(stack, '/#');
   }
+
+  existsDialog(dialog) {
+    return Object.keys(this.dialogs).includes(dialog);
+  }
 }
 
 module.exports = DialogManager;


### PR DESCRIPTION
# Pull Request Template

## PR Checklist

- [x] I have run `npm test` locally and all tests are passing.

## PR Description

With the current version, when you call accidentally a dialog that doesn't exist in the flows, the client gets stuck without giving any answer or feedback. With this change, the dialog name will be understood as a text to say instead of calling to beginDialog.

![image](https://user-images.githubusercontent.com/1809508/103865365-626c2a00-50c4-11eb-92e6-6339f3159432.png)

I think this facilitates error detection during development and enables to answer with a text starting with / that is not a dialog.