### PR TITLE
fix: gibberish detection, no deviation of vowel over consonant

### DIFF
--- a/packages/utils/src/is-gibberish.js
+++ b/packages/utils/src/is-gibberish.js
@@ -69,12 +69,12 @@ function getDeviation(value, lower, upper) {
     return Math.log(Math.abs(lower)) / logDelta;
   }
   if (value > upper) {
-    const logDelta = Math.log(value - upper);
+    const logDelta = Math.abs(Math.log(value - upper));
     if (logDelta === 0) {
       return 1;
     }
-    const max = (upper > 1 ? 1.5 : 1) - upper;
-    return Math.log(max) / logDelta;
+    const max = upper > 1 ? 1.5 : 1;
+    return Math.log(Math.abs(max)) / logDelta;
   }
   return 0;
 }
@@ -83,18 +83,19 @@ function gibberishScore(text) {
   if (text.length < 6) {
     return 0;
   }
-  const tokens = normalize(text)
+  const tokens = normalize(text.slice(0, 32))
     .split(/[\s,.!?;:([\]'"¡¿)/]+/)
     .filter((x) => x);
   const measures = getMeasures(tokens);
+  console.log(measures);
   const deviations = {
-    wordChar: getDeviation(measures.wordCharFreq, 0.15, 0.3),
-    unique: getDeviation(measures.uniqueFreq, 0.4, 1),
-    vowelOverConsonant: getDeviation(measures.vowelOverConsonant, 0.5, 1.5),
+    vowel: getDeviation(measures.vowelFreq, 0.35, 0.7),
+    unique: getDeviation(measures.uniqueFreq, 0.5, 0.9),
+    wordChar: getDeviation(measures.wordCharFreq, 0.15, 0.4),
   };
   return Math.min(
     1,
-    deviations.unique * 2 + deviations.wordChar + deviations.vowelOverConsonant
+    deviations.unique + deviations.vowel + deviations.wordChar
   );
 }
 

--- a/packages/utils/test/gibberish.test.js
+++ b/packages/utils/test/gibberish.test.js
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) AXA Group Operations Spain S.A.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
 const { isGibberish } = require('../src');
 
 describe('Gibberish', () => {
@@ -10,7 +33,15 @@ describe('Gibberish', () => {
       expect(isGibberish('sure')).toBeFalsy();
       expect(isGibberish('very much')).toBeFalsy();
       expect(isGibberish('it feels so good')).toBeFalsy();
+      expect(
+        isGibberish(
+          'Qué tiene la zarzamora que a todas horas llora que llora por los rincones'
+        )
+      ).toBeFalsy();
+      expect(isGibberish('are you a male?')).toBeFalsy();
+      expect(isGibberish('are you a female?')).toBeFalsy();
     });
+
     test('Should return true for gibberish sentences', () => {
       expect(isGibberish('zxcvwerjasc')).toBeTruthy();
       expect(isGibberish('ertrjiloifdfyyoiu')).toBeTruthy();


### PR DESCRIPTION
# Pull Request Template

## PR Checklist

- [X] I have run `npm test` locally and all tests are passing.
- [X] I have added/updated tests for any new behavior.
- [X] If this is a significant change, an issue has already been created where the problem / solution was discussed: [N/A, or add link to issue here]

## PR Description
Avoid use vowel/consontant ratio as a devaition, because is not in [0, 1] range