### PR TITLE
feat: add reset flows & contexts

### DIFF
--- a/packages/bot/src/bot.js
+++ b/packages/bot/src/bot.js
@@ -599,6 +599,34 @@ class Bot extends Clonable {
       this.nlp.addCorpus(corpus);
     }
   }
+
+  resetFlows() {
+    const logger = this.container.get('logger');
+    logger.info('reseting flows...');
+    Object.keys(this.dialogManager.dialogs).forEach(dialogKey => {
+      delete this.dialogManager.dialogs[dialogKey];
+    });
+    this.resetContexts();
+  }
+  
+  resetContexts() {
+    const logger = this.container.get('logger');
+    logger.info('reseting context in all conversations...');
+    Object.keys(this.contextManager.contextDictionary).forEach(cid => {
+      this.resetConversationContext(cid);
+    });
+  }
+
+  resetConversationContext(cid) {
+    const logger = this.container.get('logger');
+    logger.debug(`reseting context in conversation: ${cid}`);
+    const conversationCtx = this.contextManager.contextDictionary[cid];
+    Object.keys(conversationCtx).forEach(convCtxKey => {
+      delete conversationCtx[convCtxKey];
+    });
+    this.contextManager.contextDictionary[cid].dialogStack = [];
+    this.contextManager.contextDictionary[cid].variableName = undefined;
+  }
 }
 
 module.exports = Bot;

--- a/packages/bot/src/bot.js
+++ b/packages/bot/src/bot.js
@@ -600,32 +600,25 @@ class Bot extends Clonable {
     }
   }
 
-  resetFlows() {
+  async resetFlows() {
     const logger = this.container.get('logger');
     logger.info('reseting flows...');
     Object.keys(this.dialogManager.dialogs).forEach(dialogKey => {
       delete this.dialogManager.dialogs[dialogKey];
     });
-    this.resetContexts();
+    await this.resetContexts();
   }
   
-  resetContexts() {
+  async resetContexts() {
     const logger = this.container.get('logger');
     logger.info('reseting context in all conversations...');
-    Object.keys(this.contextManager.contextDictionary).forEach(cid => {
-      this.resetConversationContext(cid);
-    });
+    await this.contextManager.resetConversations();
   }
 
-  resetConversationContext(cid) {
+  async resetConversationContext(cid) {
     const logger = this.container.get('logger');
     logger.debug(`reseting context in conversation: ${cid}`);
-    const conversationCtx = this.contextManager.contextDictionary[cid];
-    Object.keys(conversationCtx).forEach(convCtxKey => {
-      delete conversationCtx[convCtxKey];
-    });
-    this.contextManager.contextDictionary[cid].dialogStack = [];
-    this.contextManager.contextDictionary[cid].variableName = undefined;
+    await this.contextManager.resetConversation(cid);
   }
 }
 

--- a/packages/nlp/src/context-manager.js
+++ b/packages/nlp/src/context-manager.js
@@ -119,6 +119,23 @@ class ContextManager extends Clonable {
       }
     }
   }
+
+  async resetConversations() {
+    Object.keys(this.contextDictionary).forEach(async (cid) => {
+      await this.resetConversation(cid);
+    });
+  }
+
+  async resetConversation(cid) {
+    const logger = this.container.get('logger');
+    logger.debug(`reseting context in conversation: ${cid}`);
+    const conversationCtx = this.contextDictionary[cid];
+    Object.keys(conversationCtx).forEach(convCtxKey => {
+      delete conversationCtx[convCtxKey];
+    });
+    this.contextDictionary[cid].dialogStack = [];
+    this.contextDictionary[cid].variableName = undefined;
+  }
 }
 
 module.exports = ContextManager;


### PR DESCRIPTION
# Pull Request Template

## PR Checklist

- [x] I have run `npm test` locally and all tests are passing.

## PR Description

In the current implementation there's no direct way to reset flows & contexts before calling `bot.loadScript(...)` with new content from the application. With this PR we cover both cases. It's also possible to remove context for a single conversation.