### PR TITLE
fix: set ctx using database

### DIFF
--- a/packages/nlp/src/context-manager.js
+++ b/packages/nlp/src/context-manager.js
@@ -112,15 +112,15 @@ class ContextManager extends Clonable {
           await database.update(this.settings.tableName, clone, {
             upsert: true,
           });
-          if (this.onCtxUpdate) {
-            logger.debug(`emmitting event onCtxUpdate...`);
-            await this.onCtxUpdate(clone);
-          }
         } else {
           this.contextDictionary[id] = clone;
         }
       } else {
         this.contextDictionary[id] = clone;
+      }
+      if (this.onCtxUpdate) {
+        logger.debug(`emmitting event onCtxUpdate...`);
+        await this.onCtxUpdate(clone);
       }
     }
   }

--- a/packages/nlp/src/context-manager.js
+++ b/packages/nlp/src/context-manager.js
@@ -109,9 +109,7 @@ class ContextManager extends Clonable {
           : undefined;
         if (database) {
           clone.id = id;
-          await database.update(this.settings.tableName, clone, {
-            upsert: true,
-          });
+          await database.save(this.settings.tableName, clone);
         } else {
           this.contextDictionary[id] = clone;
         }

--- a/packages/nlp/src/context-manager.js
+++ b/packages/nlp/src/context-manager.js
@@ -72,15 +72,9 @@ class ContextManager extends Clonable {
     let result;
     if (id) {
       if (this.settings.tableName) {
-        const database = this.container
-          ? this.container.get('database')
-          : undefined;
+        const database = this.container ? this.container.get('database') : undefined;
         if (database) {
-          result = (await database.findOne(this.settings.tableName, {
-            conversationId: id,
-          })) || {
-            id,
-          };
+          result = (await database.findOne(this.settings.tableName, { conversationId: id, })) || { conversationId: id, };
         }
       }
       if (!result) {
@@ -105,12 +99,14 @@ class ContextManager extends Clonable {
         }
       }
       if (this.settings.tableName) {
-        const database = this.container
-          ? this.container.get('database')
-          : undefined;
+        const database = this.container ? this.container.get('database') : undefined;
         if (database) {
-          const saved = await database.save(this.settings.tableName, clone);
-          context.id = saved.id;
+          clone.id = id;
+          await database.update(this.settings.tableName, clone, { upsert: true });
+          if (this.onCtxUpdate) {
+            logger.debug(`emmitting event onCtxUpdate...`);
+            await this.onCtxUpdate(clone);
+          }
         } else {
           this.contextDictionary[id] = clone;
         }

--- a/packages/nlp/src/context-manager.js
+++ b/packages/nlp/src/context-manager.js
@@ -72,9 +72,13 @@ class ContextManager extends Clonable {
     let result;
     if (id) {
       if (this.settings.tableName) {
-        const database = this.container ? this.container.get('database') : undefined;
+        const database = this.container
+          ? this.container.get('database')
+          : undefined;
         if (database) {
-          result = (await database.findOne(this.settings.tableName, { conversationId: id, })) || { conversationId: id, };
+          result = (await database.findOne(this.settings.tableName, {
+            conversationId: id,
+          })) || { conversationId: id };
         }
       }
       if (!result) {
@@ -88,6 +92,7 @@ class ContextManager extends Clonable {
   }
 
   async setContext(input, context) {
+    const logger = this.container.get('logger');
     const id = await this.getInputContextId(input);
     if (id) {
       const keys = Object.keys(context);
@@ -99,10 +104,14 @@ class ContextManager extends Clonable {
         }
       }
       if (this.settings.tableName) {
-        const database = this.container ? this.container.get('database') : undefined;
+        const database = this.container
+          ? this.container.get('database')
+          : undefined;
         if (database) {
           clone.id = id;
-          await database.update(this.settings.tableName, clone, { upsert: true });
+          await database.update(this.settings.tableName, clone, {
+            upsert: true,
+          });
           if (this.onCtxUpdate) {
             logger.debug(`emmitting event onCtxUpdate...`);
             await this.onCtxUpdate(clone);
@@ -126,7 +135,7 @@ class ContextManager extends Clonable {
     const logger = this.container.get('logger');
     logger.debug(`reseting context in conversation: ${cid}`);
     const conversationCtx = this.contextDictionary[cid];
-    Object.keys(conversationCtx).forEach(convCtxKey => {
+    Object.keys(conversationCtx).forEach((convCtxKey) => {
       delete conversationCtx[convCtxKey];
     });
     this.contextDictionary[cid].dialogStack = [];


### PR DESCRIPTION
# Pull Request Template

## PR Checklist

- [x] I have run `npm test` locally and all tests are passing.

## PR Description

With the current implementation, using a database to get & set context, using database.save introduced more than one version of the context for the same conversation. Flows stopped to work on that point because dialogStack remains inconsistent.

I fix this using database.update with upsert set to true, to keep a single source of truth. I also add an event emission `onCtxUpdate` to be able to listen for context updates, useful for example to store dialog stack changes from the application.