### PR TITLE
fix: errors on BaseStemmer.stem returning undefined

### DIFF
--- a/packages/core/src/base-stemmer.js
+++ b/packages/core/src/base-stemmer.js
@@ -320,9 +320,9 @@ class BaseStemmer {
   stemWords(words) {
     const results = [];
     for (let i = 0; i < words.length; i++) {
-      const stemmed = this.stemWord(words[i]).trim();
+      const stemmed = this.stemWord(words[i]);
       if (stemmed) {
-        results.push(stemmed);
+        results.push(stemmed.trim());
       }
     }
     return results;


### PR DESCRIPTION
# Pull Request Template

## PR Checklist

- [ ] I have run `npm test` locally and all tests are passing.
- [ ] I have added/updated tests for any new behavior.
- [ ] If this is a significant change, an issue has already been created where the problem / solution was discussed: [N/A, or add link to issue here]

## PR Description

Ran across this trying to train my data. I didn't look into why `stem` was returning undefined. This is just a small patch.
