### PR TITLE
fix: send context always that a session.say is executed

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6554,7 +6554,8 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
       "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "handlebars": {
       "version": "4.7.6",
@@ -7206,6 +7207,7 @@
       "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
       "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
       "dev": true,
+      "optional": true,
       "requires": {
         "is-docker": "^2.0.0"
       }
@@ -8896,6 +8898,7 @@
       "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-8.0.1.tgz",
       "integrity": "sha512-BvEXF+UmsnAfYfoapKM9nGxnP+Wn7P91YfXmrKnfcYCx6VBeoN5Ez5Ogck6I8Bi5k4RlpqRYaw75pAwzX9OphA==",
       "dev": true,
+      "optional": true,
       "requires": {
         "growly": "^1.3.0",
         "is-wsl": "^2.2.0",
@@ -8909,7 +8912,8 @@
           "version": "8.3.2",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
           "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -10270,7 +10274,8 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
       "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "signal-exit": {
       "version": "3.0.3",

--- a/packages/bot/src/bot.js
+++ b/packages/bot/src/bot.js
@@ -187,7 +187,7 @@ class Bot extends Clonable {
             if (this.dialogManager.existsDialog(dialog)) {
               session.beginDialog(context, dialog);
             } else {
-              await session.say(dialog);
+              await session.say(dialog, context);
             }
             break;
           case 'ask':
@@ -209,15 +209,15 @@ class Bot extends Clonable {
                 ) {
                   session.beginDialog(context, result.answer);
                 } else {
-                  await session.say(result.answer);
+                  await session.say(result.answer, context);
                 }
               } else if (session.activity.file && this.onFile) {
                 await this.onFile(this, session);
               } else {
-                await session.say("Sorry, I don't understand");
+                await session.say("Sorry, I don't understand", context);
               }
             } else {
-              await session.say("Sorry, I don't understand");
+              await session.say("Sorry, I don't understand", context);
             }
             break;
           case 'call':
@@ -290,7 +290,10 @@ class Bot extends Clonable {
             session.restartDialog(context);
           }
         } else {
-          await session.say(context.validation.message || 'Invalid value');
+          await session.say(
+            context.validation.message || 'Invalid value',
+            context
+          );
           return false;
         }
       }

--- a/packages/bot/src/dialog-manager.js
+++ b/packages/bot/src/dialog-manager.js
@@ -23,13 +23,13 @@
 
 const { Clonable } = require('@nlpjs/core');
 
-async function defaultAction(session) {
+async function defaultAction(session, context) {
   const nlp = this.container.get('nlp');
   if (nlp) {
     const result = await nlp.process(session.text);
-    session.say(result.answer || "Sorry, I don't understand");
+    session.say(result.answer || "Sorry, I don't understand", context);
   } else {
-    session.say('Sorry, I have problems connecting to my brain');
+    session.say('Sorry, I have problems connecting to my brain', context);
   }
 }
 


### PR DESCRIPTION
# Pull Request Template

## PR Checklist

- [X] I have run `npm test` locally and all tests are passing.
- [ ] I have added/updated tests for any new behavior.
- [ ] If this is a significant change, an issue has already been created where the problem / solution was discussed: [N/A, or add link to issue here]

## PR Description
Always that a session.say happen, we have to send the context so string templating is done.