### PR TITLE
feat: set variable don't asume that input is string

### DIFF
--- a/packages/bot/src/bot.js
+++ b/packages/bot/src/bot.js
@@ -135,7 +135,7 @@ class Bot extends Clonable {
   async setVariable(context, variableName, variableValue) {
     if (this.evaluator) {
       await this.evaluator.evaluate(
-        `${variableName} = "${variableValue}"`,
+        `${variableName} = ${variableValue}`,
         context
       );
     } else {
@@ -327,7 +327,11 @@ class Bot extends Clonable {
       if (context.validatorName) {
         shouldContinue = await this.runValidation(session, context);
       } else if (context.variableName) {
-        await this.setVariable(context, context.variableName, session.text);
+        await this.setVariable(
+          context,
+          context.variableName,
+          `"${session.text}"`
+        );
       }
     }
     if (shouldContinue) {

--- a/packages/bot/test/script4.dlg
+++ b/packages/bot/test/script4.dlg
@@ -6,8 +6,8 @@ translations en
 dialog main
   say What's your language
   ask userLanguage
-  [userLanguage === 'English'] set locale en
-  [userLanguage === 'Spanish'] set locale es
+  [userLanguage === 'English'] set locale "en"
+  [userLanguage === 'Spanish'] set locale "es"
   say What's your name?
   ask userName
   say Your name is {{ userName }}


### PR DESCRIPTION
# Pull Request Template

## PR Checklist

- [X] I have run `npm test` locally and all tests are passing.
- [ ] I have added/updated tests for any new behavior.
- [ ] If this is a significant change, an issue has already been created where the problem / solution was discussed: [N/A, or add link to issue here]

## PR Description
Bot **set** does not asume now that input is string. 
Breaking change: now to set a variable with an string value, it must be quoted