### PR TITLE
fix: address with conversation id is mandatory in activity

### DIFF
--- a/packages/rest-connector/src/rest-connector.js
+++ b/packages/rest-connector/src/rest-connector.js
@@ -62,6 +62,7 @@ class RestConnector extends Connector {
           channelId: 'rest',
           text: req.query.text,
           conversation: { id: req.query.conversationId },
+          address: { conversation: { id: req.query.conversationId } },
         });
         session.res = res;
         await bot.process(session);


### PR DESCRIPTION
# Pull Request Template

## PR Checklist

- [X] I have run `npm test` locally and all tests are passing.
- [ ] I have added/updated tests for any new behavior.
- [ ] If this is a significant change, an issue has already been created where the problem / solution was discussed: [N/A, or add link to issue here]

## PR Description
At REST connector, activity is created. It should include an address with conversation id for correct context retrieval.