### PR TITLE
fix: when retries is 0 it was identified as 2

### DIFF
--- a/packages/bot/src/bot.js
+++ b/packages/bot/src/bot.js
@@ -278,7 +278,10 @@ class Bot extends Clonable {
         context.validation.currentRetry =
           (context.validation.currentRetry || 0) + 1;
         if (
-          context.validation.currentRetry > (context.validation.retries || 2)
+          context.validation.currentRetry > context.validation.retries ===
+          undefined
+            ? 2
+            : context.validation.retries
         ) {
           if (context.validation.failDialog) {
             let { failDialog } = context.validation;
@@ -321,6 +324,9 @@ class Bot extends Clonable {
       for (let i = 0; i < keys.length; i += 1) {
         context[keys[i]] = session.activity.value[keys[i]];
       }
+    }
+    if (this.onBeforeProcess) {
+      await this.onBeforeProcess(session, context);
     }
     let shouldContinue = true;
     if (context.isWaitingInput) {


### PR DESCRIPTION
# Pull Request Template

## PR Checklist

- [X] I have run `npm test` locally and all tests are passing.
- [ ] I have added/updated tests for any new behavior.
- [ ] If this is a significant change, an issue has already been created where the problem / solution was discussed: [N/A, or add link to issue here]

## PR Description

When validation retries was 0 there was a fallback to number 2. 