### PR TITLE
feat: translations allow now a fallback language and not only master …

### DIFF
--- a/packages/bot/src/bot-localization.js
+++ b/packages/bot/src/bot-localization.js
@@ -39,7 +39,11 @@ class BotLocalization {
     if (!this.localizations[key]) {
       return srckey;
     }
-    return this.localizations[key][locale] || srckey;
+    return (
+      this.localizations[key][locale] ||
+      this.localizations[key][this.fallbackLocale] ||
+      srckey
+    );
   }
 
   removeLocale(locale) {
@@ -59,14 +63,15 @@ class BotLocalization {
         this.addRule(rule[i]);
       }
     } else {
-      const master = rule.masterLocale || 'en';
+      this.masterLocale = rule.masterLocale || 'en';
+      this.fallbackLocale = rule.fallbackLocale || this.masterLocale;
       let key;
       for (let i = 0; i < rule.rules.length; i += 1) {
         const current = rule.rules[i].trim();
         const index = current.indexOf(' ');
         const locale = current.slice(0, index).trim();
         const sentence = current.slice(index).trim();
-        if (locale === master) {
+        if (locale === this.masterLocale) {
           key = sentence;
         }
         this.addLocalization(locale, key, sentence);

--- a/packages/bot/src/bot.js
+++ b/packages/bot/src/bot.js
@@ -396,7 +396,11 @@ class Bot extends Clonable {
     let locale = 'en';
     let currentIntent = {};
     let currentEntity = {};
-    let currentTranslations = { masterLocale: 'en', rules: [] };
+    let currentTranslations = {
+      masterLocale: 'en',
+      fallbackLocale: 'en',
+      rules: [],
+    };
     const translations = [];
     let state;
     const dialogs = [];
@@ -412,6 +416,7 @@ class Bot extends Clonable {
         current.line += ` ${current.type.slice(3)}`;
         current.type = 'ask';
       }
+      let splitted;
       switch (current.type) {
         case 'language':
           locale = current.line;
@@ -419,8 +424,10 @@ class Bot extends Clonable {
         case 'comment':
           break;
         case 'translations':
+          splitted = current.line ? current.line.split(' ') : ['en', 'en'];
           currentTranslations = {
-            masterLocale: current.line || 'en',
+            masterLocale: splitted[0] || 'en',
+            fallbackLocale: splitted[1] || splitted[0] || 'en',
             rules: [],
           };
           translations.push(currentTranslations);

--- a/packages/bot/test/bot.test.js
+++ b/packages/bot/test/bot.test.js
@@ -84,5 +84,23 @@ describe('Bot', () => {
       await connector.runScript('./packages/bot/test/scenario02.dlt');
       expect(connector.messages).toEqual(connector.expected);
     });
+    test('It should be able to process a conversation with fallback locale', async () => {
+      const bot = new Bot({ container });
+      container.register('bot', bot, true);
+      await bot.start();
+      await bot.loadScript(['./packages/bot/test/script5.dlg']);
+      const connector = new TestConnector({ container });
+      await connector.runScript('./packages/bot/test/scenario05-01.dlt');
+      expect(connector.messages).toEqual(connector.expected);
+    });
+    test('It should be able to process a conversation with fallback locale falling', async () => {
+      const bot = new Bot({ container });
+      container.register('bot', bot, true);
+      await bot.start();
+      await bot.loadScript(['./packages/bot/test/script5.dlg']);
+      const connector = new TestConnector({ container });
+      await connector.runScript('./packages/bot/test/scenario05-02.dlt');
+      expect(connector.messages).toEqual(connector.expected);
+    });
   });
 });

--- a/packages/bot/test/scenario05-01.dlt
+++ b/packages/bot/test/scenario05-01.dlt
@@ -1,0 +1,8 @@
+user> hello
+bot> What's your language
+user> Spanish
+bot> Cuál es tu nombre?
+user> John
+bot> Tu nombre es John
+bot> This message does not exists in spanish
+bot> MSG004

--- a/packages/bot/test/scenario05-02.dlt
+++ b/packages/bot/test/scenario05-02.dlt
@@ -1,0 +1,8 @@
+user> hello
+bot> What's your language
+user> English
+bot> What's your name?
+user> John
+bot> Your name is John
+bot> This message does not exists in spanish
+bot> MSG004

--- a/packages/bot/test/script5.dlg
+++ b/packages/bot/test/script5.dlg
@@ -1,0 +1,20 @@
+translations zz en
+  - zz MSG001
+  - en What's your name?
+  - es Cuál es tu nombre?
+  - zz MSG002
+  - en Your name is {{ userName }}
+  - es Tu nombre es {{ userName }}
+  - zz MSG003
+  - en This message does not exists in spanish
+  - zz MSG004
+dialog main
+  say What's your language
+  ask userLanguage
+  [userLanguage === 'English'] set locale "en"
+  [userLanguage === 'Spanish'] set locale "es"
+  say MSG001
+  ask userName
+  say MSG002
+  say MSG003
+  say MSG004


### PR DESCRIPTION
…language

# Pull Request Template

## PR Checklist

- [X] I have run `npm test` locally and all tests are passing.
- [X] I have added/updated tests for any new behavior.
- [X] If this is a significant change, an issue has already been created where the problem / solution was discussed: [N/A, or add link to issue here]

## PR Description

Now translations can have a master locale (locale for the key, it can be invented one like zz) and a fallback locale.
That way you can define translations with keys like MSG001 being translated to the locale that you want.