### PR TITLE
fix: don't crash when NER threshold is 1 and there are regex

### DIFF
--- a/packages/ner/src/extractor-enum.js
+++ b/packages/ner/src/extractor-enum.js
@@ -248,44 +248,47 @@ class ExtractorEnum {
   }
 
   extractFromRule(text, rule, words, threshold) {
-    const edges = [];
-    if (threshold >= 1) {
-      if (!rule.dict) {
-        this.buildRuleDict(rule);
-      }
-      const newEdges = this.getBestExact(text, words, rule);
-      for (let i = 0; i < newEdges.length; i += 1) {
-        edges.push(newEdges[i]);
-      }
-    } else {
-      for (let i = 0; i < rule.rules.length; i += 1) {
-        const current = rule.rules[i];
-        if (current && current.option && Array.isArray(current.texts)) {
-          for (let j = 0; j < current.texts.length; j += 1) {
-            const newEdges = this.getBestSubstringList(
-              text,
-              current.texts[j],
-              words,
-              current.threshold || threshold
-            );
-            for (let k = 0; k < newEdges.length; k += 1) {
-              edges.push({
-                ...newEdges[k],
-                entity: rule.name,
-                type: rule.type,
-                option: rule.rules[i].option,
-                sourceText: current.texts[j],
-                utteranceText: text.substring(
-                  newEdges[k].start,
-                  newEdges[k].end + 1
-                ),
-              });
+    if (rule.type === 'enum') {
+      const edges = [];
+      if (threshold >= 1) {
+        if (!rule.dict) {
+          this.buildRuleDict(rule);
+        }
+        const newEdges = this.getBestExact(text, words, rule);
+        for (let i = 0; i < newEdges.length; i += 1) {
+          edges.push(newEdges[i]);
+        }
+      } else {
+        for (let i = 0; i < rule.rules.length; i += 1) {
+          const current = rule.rules[i];
+          if (current && current.option && Array.isArray(current.texts)) {
+            for (let j = 0; j < current.texts.length; j += 1) {
+              const newEdges = this.getBestSubstringList(
+                text,
+                current.texts[j],
+                words,
+                current.threshold || threshold
+              );
+              for (let k = 0; k < newEdges.length; k += 1) {
+                edges.push({
+                  ...newEdges[k],
+                  entity: rule.name,
+                  type: rule.type,
+                  option: rule.rules[i].option,
+                  sourceText: current.texts[j],
+                  utteranceText: text.substring(
+                    newEdges[k].start,
+                    newEdges[k].end + 1
+                  ),
+                });
+              }
             }
           }
         }
       }
+      return edges;
     }
-    return edges;
+    return [];
   }
 
   extract(srcInput) {


### PR DESCRIPTION
# Pull Request Template

## PR Checklist

- [X] I have run `npm test` locally and all tests are passing.
- [ ] I have added/updated tests for any new behavior.
- [ ] If this is a significant change, an issue has already been created where the problem / solution was discussed: [N/A, or add link to issue here]

## PR Description

Bug when NER threshold is 1 and there is a regex rule.
https://github.com/axa-group/nlp.js/issues/778