### PR TITLE
feat: locale can be set at rest connector token creation

### DIFF
--- a/packages/rest-connector/src/rest-connector.js
+++ b/packages/rest-connector/src/rest-connector.js
@@ -50,7 +50,19 @@ class RestConnector extends Connector {
 
     server.get(`${this.settings.apiTag}/token`, async (req, res) => {
       this.log('debug', `GET ${this.settings.apiTag}/token`);
-      res.status(200).send({ id: uuid() });
+      const id = uuid();
+      if (req.query && req.query.locale) {
+        const contextManager = this.container.get('context-manager');
+        if (contextManager) {
+          const activity = { address: { conversation: { id } } };
+          const context = await contextManager.getContext({ activity });
+          if (context) {
+            context.locale = req.query.locale;
+          }
+          await contextManager.setContext({ activity }, context);
+        }
+      }
+      res.status(200).send({ id });
     });
 
     server.get(`${this.settings.apiTag}/talk`, async (req, res) => {


### PR DESCRIPTION
# Pull Request Template

## PR Checklist

- [X] I have run `npm test` locally and all tests are passing.
- [ ] I have added/updated tests for any new behavior.
- [ ] If this is a significant change, an issue has already been created where the problem / solution was discussed: [N/A, or add link to issue here]

## PR Description
Get locale at /rest/token of rest-connector