### PR TITLE
Feature/custom client path

### DIFF
--- a/packages/express-api-server/src/express-api-app.js
+++ b/packages/express-api-server/src/express-api-app.js
@@ -24,6 +24,7 @@
 const express = require('express');
 const cors = require('cors');
 const path = require('path');
+const { logger } = require('@nlpjs/core');
 
 class ExpressApiApp {
   constructor(settings, plugins, routers) {
@@ -37,7 +38,6 @@ class ExpressApiApp {
   }
 
   initialize() {
-    const logger = this.settings.container.get('logger');
     this.app = express();
     this.app.use(cors());
     this.app.use(express.urlencoded({ extended: false }));
@@ -46,13 +46,14 @@ class ExpressApiApp {
       this.app.use(this.plugins[i]);
     }
     if (this.settings.serveBot) {
-      const clientPath = this.settings.clientPath || path.join(__dirname, './public');
+      const clientPath =
+        this.settings.clientPath || path.join(__dirname, './public');
       logger.debug(`Serving bot client (path: ${clientPath}`);
       this.app.use(express.static(clientPath));
     }
     for (let i = 0; i < this.routers.length; i += 1) {
       const router = this.routers[i];
-      const routes = router.stack.map((layer) => layer.route.path);
+      const routes = router.stack.map(layer => layer.route.path);
       logger.debug(`Loading custom router: ${JSON.stringify(routes, null, 2)}`);
       this.app.use(this.settings.apiRoot, router);
     }

--- a/packages/express-api-server/src/express-api-app.js
+++ b/packages/express-api-server/src/express-api-app.js
@@ -37,6 +37,7 @@ class ExpressApiApp {
   }
 
   initialize() {
+    const logger = this.settings.container.get('logger');
     this.app = express();
     this.app.use(cors());
     this.app.use(express.urlencoded({ extended: false }));
@@ -45,7 +46,9 @@ class ExpressApiApp {
       this.app.use(this.plugins[i]);
     }
     if (this.settings.serveBot) {
-      this.app.use(express.static(path.join(__dirname, './public')));
+      const clientPath = this.settings.clientPath || path.join(__dirname, './public');
+      logger.debug(`Serving bot client (path: ${clientPath}`);
+      this.app.use(express.static(clientPath));
     }
     for (let i = 0; i < this.routers.length; i += 1) {
       this.app.use(this.settings.apiRoot, this.routers[i]);

--- a/packages/express-api-server/src/express-api-app.js
+++ b/packages/express-api-server/src/express-api-app.js
@@ -51,7 +51,10 @@ class ExpressApiApp {
       this.app.use(express.static(clientPath));
     }
     for (let i = 0; i < this.routers.length; i += 1) {
-      this.app.use(this.settings.apiRoot, this.routers[i]);
+      const router = this.routers[i];
+      const routes = router.stack.map((layer) => layer.route.path);
+      logger.debug(`Loading custom router: ${JSON.stringify(routes, null, 2)}`);
+      this.app.use(this.settings.apiRoot, router);
     }
     return this.app;
   }


### PR DESCRIPTION
## PR Checklist

- [x] I have run `npm test` locally and all tests are passing.

## PR Description

Added the possibility to customize client path when using package express-api-server.
Also added some interesting logs to check which routes are loaded.

Example:

```
const conf = {
  ...
  settings: {
    'api-server': {
      serveBot: true,
      clientPath: path.join(__dirname, '..', 'public')
    }
  }
  ...
};
const dock = await dockStart(conf);
```
