### PR TITLE
feat: return None classification when no perceptron at network

### DIFF
--- a/packages/nlu/src/nlu-neural.js
+++ b/packages/nlu/src/nlu-neural.js
@@ -35,7 +35,7 @@ class NeuralNlu extends Nlu {
   innerProcess(srcInput) {
     const input = srcInput;
     input.classifications = this.neuralNetwork
-      ? this.neuralNetwork.run(input.tokens)
+      ? this.neuralNetwork.run(input.tokens) || { None: 1 }
       : { None: 1 };
     this.convertToArray(input);
     const { intent } = input.classifications[0];


### PR DESCRIPTION
# Pull Request Template

## PR Checklist

- [X] I have run `npm test` locally and all tests are passing.
- [ ] I have added/updated tests for any new behavior.
- [ ] If this is a significant change, an issue has already been created where the problem / solution was discussed: [N/A, or add link to issue here]

## PR Description
When there is no perceptron at the dense network, it returned undefined. The problem is that this cause classifications[0] to not exists. Then by default if undefined is returned, then return { None: 1 }