### PR TITLE
fix(nlu): can handle zero-byte string in Nlu#prepare

### DIFF
--- a/packages/nlu/src/nlu.js
+++ b/packages/nlu/src/nlu.js
@@ -147,10 +147,17 @@ class Nlu extends Clonable {
         }
         return result;
       }
-      const item = settings.fieldNameSrc
+      let item = settings.fieldNameSrc
         ? text[settings.fieldNameSrc]
-        : text.text || text.utterance || text.texts || text.utterances;
-      if (item) {
+        : text.texts || text.utterances;
+      if(!item && typeof item !== "string") {
+        if(typeof text.text === "string") {
+          item = text.text;
+        } else if(typeof text.utterance === "string") {
+          item = text.utterance;
+        }
+      }
+      if (item || typeof item === "string") {
         const result = await this.prepare(item, settings);
         const targetField = settings.fieldNameTgt || 'tokens';
         return { [targetField]: result, ...text };

--- a/packages/nlu/test/domain-manager.test.js
+++ b/packages/nlu/test/domain-manager.test.js
@@ -283,6 +283,14 @@ describe('Domain Manager', () => {
       expect(actual.classifications[0].intent).toEqual('order.check');
       expect(actual.classifications[0].score).toBeGreaterThan(0.5);
     });
+    test('Can process zero-byte strings', async () => {
+      const manager = new DomainManager({ container, trainByDomain: true });
+      addFoodDomain(manager);
+      addPersonalityDomain(manager);
+      await manager.train();
+      const actual = await manager.process('');
+      expect(actual.classifications[0].score).toEqual(0);
+    });
     test('Will have score 1 if stems are in stem dict', async () => {
       const manager = new DomainManager({ container, trainByDomain: true });
       addFoodDomain(manager);

--- a/packages/nlu/test/nlu.test.js
+++ b/packages/nlu/test/nlu.test.js
@@ -83,6 +83,12 @@ describe('NLU', () => {
         'Error at nlu.prepare: expected a text but received [object Object]'
       );
     });
+    test('Prepare can tolerate zero-byte string texts', async () => {
+      const nlu = new Nlu({ locale: 'en', keepStopwords: false }, container);
+      const input = '';
+      const actual = await nlu.prepare(input);
+      expect(actual).toEqual({});
+    });
     test('Prepare can process an array of strings', async () => {
       const nlu = new Nlu({ locale: 'en', keepStopwords: false }, container);
       const input = ['Allí hay un ratón', 'y vino el señor doctor'];


### PR DESCRIPTION
## PR Checklist

- [ ] I have run `npm test` locally and all tests are passing.
   Unable to complete `lerna bootstrap` due to some network reasons in my environment, only tests in `packages/nlu` have been run.
- [x] I have added/updated tests for any new behavior.
- [x] Insignificant change

## PR Description

```js
(async () => {
  const container = await containerBootstrap();
  const manager = new DomainManager({ container, trainByDomain: false });
  await manager.train();
  const actual = await manager.process('');
  // will throw "Error at nlu.prepare: expected a text but received [object Object]"
  // which is confusing and apparently not intended.
  console.log(actual);
})();
```