### PR TITLE
fix #1081: Allow parenthesis in `say` actions

### DIFF
--- a/packages/bot/src/dialog-parse.js
+++ b/packages/bot/src/dialog-parse.js
@@ -60,7 +60,7 @@ const CARD_LINK_REGEX = /!?\[.{0,100}\]\(https?:\/\/.{0,2048}\)/gi;
 function trimLine(line) {
   const trimmedCondition = trimBetween(line.trim(), '[', ']', true);
   let trimmedSettings;
-  if (CARD_LINK_REGEX.test(line)) {
+  if (CARD_LINK_REGEX.test(line) || line.toLowerCase().startsWith('say ')) {
     trimmedSettings = {
       line,
       trimmed: '',


### PR DESCRIPTION
When having a dialog which includes a `say` action text within brackets, the text inside brackets is removed and assumed to be settings of the `say` action.

The [trimBetween()](https://github.com/axa-group/nlp.js/blob/master/packages/bot/src/dialog-parse.js#L37) function parses everything inside brackets as settings:

```
dialog my_dialog
  say Something (clarifying) whatever
```

Would be parsed as the following actions:
```json
[
    {
        "type": "dialog",
        "srcLine": "dialog my_dialog",
        "line": "my_dialog",
        "condition": "",
        "settings": ""
    },
    {
        "type": "say",
        "srcLine": "say Something (clarifying) whatever",
        "line": "Something  whatever",
        "condition": "",
        "settings": "clarifying"
    }
]
```

# Pull Request Template

## PR Checklist

- [ ] I have run `npm test` locally and all tests are passing.
- [ ] I have added/updated tests for any new behavior.
- [ ] If this is a significant change, an issue has already been created where the problem / solution was discussed: [N/A, or add link to issue here]

## PR Description

<!-- Describe Your PR Here! -->