### PR TITLE
Feature/base stemmer hidden properties

### DIFF
--- a/packages/core/src/base-stemmer.js
+++ b/packages/core/src/base-stemmer.js
@@ -302,13 +302,13 @@ class BaseStemmer {
   stemWord(word) {
     let result = this.cache[`.${word}`];
     if (result == null) {
-      if (this.dictionary.before[word]) {
+      if (this.dictionary.before.hasOwnProperty(word)) {
         result = this.dictionary.before[word];
       } else {
         this.setCurrent(word);
         this.innerStem();
         result = this.getCurrent();
-        if (this.dictionary.after[result]) {
+        if (this.dictionary.after.hasOwnProperty(result)) {
           result = this.dictionary.after[result];
         }
       }

--- a/packages/lang-en/test/stemmer-en.test.js
+++ b/packages/lang-en/test/stemmer-en.test.js
@@ -203,6 +203,13 @@ describe('Stemmer', () => {
       const actual = stemmer.stem(tokens);
       expect(actual).toEqual(expected);
     });
+    test('Should stem "is the app called constructor?"', () => {
+      const input = 'is the app called constructor?';
+      const expected = ['is', 'the', 'app', 'call', 'constructor'];
+      const tokens = tokenizer.tokenize(normalizer.normalize(input));
+      const actual = stemmer.stem(tokens);
+      expect(actual).toEqual(expected);
+    });
   });
 
   describe('Tokenize and stem', () => {

--- a/packages/nlu/src/nlu.js
+++ b/packages/nlu/src/nlu.js
@@ -209,7 +209,7 @@ class Nlu extends Clonable {
         output: { [intent]: 1 },
       };
       const keys = Object.keys(item.input);
-      if (!this.intentFeatures[intent]) {
+      if (!Object.prototype.hasOwnProperty.call(this.intentFeatures, intent)) {
         this.intentFeatures[intent] = {};
       }
       for (let j = 0; j < keys.length; j += 1) {
@@ -226,7 +226,9 @@ class Nlu extends Clonable {
       const features = Object.keys(this.intentFeatures[intent]);
       for (let j = 0; j < features.length; j += 1) {
         const feature = features[j];
-        if (!this.featuresToIntent[feature]) {
+        if (
+          !Object.prototype.hasOwnProperty.call(this.featuresToIntent, feature)
+        ) {
           this.featuresToIntent[feature] = [];
         }
         this.featuresToIntent[feature].push(intent);


### PR DESCRIPTION
- [Issue 1100](https://github.com/axa-group/nlp.js/issues/1100)

## PR Description

This will fix crashes in nlu.js/base-stemmer.js, when the stemmer dictionary or intentFeatures/featuresToIntent objects are checked for properties like 'constructor'. Constructor is a valid word that can be used inside an utterance. Checking an empty object for the property 'constructor' by using the bracket notation will return a function, instead of undefined.