### PR TITLE
Fix intents array on json load

### DIFF
--- a/packages/nlu/src/nlu.js
+++ b/packages/nlu/src/nlu.js
@@ -480,6 +480,7 @@ class Nlu extends Clonable {
     this.applySettings(this.settings, json.settings);
     this.features = json.features || {};
     this.intents = json.intents || {};
+    this.intentsArr = Object.keys(json.intents);
     this.featuresToIntent = json.featuresToIntent || {};
     this.intentFeatures = json.intentFeatures || {};
     this.spellCheck.setFeatures(this.features);


### PR DESCRIPTION
If you are using a single instance of the `Nlu` class and loading different models using `fromJSON` only the first configuration will work for intent classification. This is because the `convertToArray` function keeps the same `intentsArr` built from the keys in the `intents` property. Loading from json resets the `intents` property but not `intentsArr`. If you change models using fromJSON the `intentsArr` from the first model will stick around an you'll always get no intent classifications. 

This PR resets the `intentsArr` property to the `intents` keys every time you load from JSON.  