### PR TITLE
Add the missing word "keinen"

### DIFF
--- a/packages/lang-de/src/sentiment/negations_de.json
+++ b/packages/lang-de/src/sentiment/negations_de.json
@@ -1,3 +1,3 @@
 {
-  "words": ["nicht", "garnicht", "kein", "keine", "keines", "keinem", "keiner", "keinesfalls", "keineswegs"]
+  "words": ["nicht", "garnicht", "kein", "keine", "keines", "keinem", "keinen", "keiner", "keinesfalls", "keineswegs"]
 }


### PR DESCRIPTION
"Keinen" is the accusative case of kein.
In German language there're 3 genera with corresponding forms:
female: keine - keine - keiner - keiner
neutral: kein - kein - keinem - keines
Male: kein - KEINEN - keinem - keines
So I added the only missing one.