### PR TITLE
feat: Optimize slot finding answer processing

### DIFF
--- a/packages/nlg/src/action-manager.js
+++ b/packages/nlg/src/action-manager.js
@@ -100,7 +100,7 @@ class ActionManager extends Clonable {
    */
   async processActions(intent, input) {
     const actionList = this.findActions(intent);
-    if (typeof input === 'object') {
+    if (input && typeof input === 'object') {
       input.actions = actionList.map((x) => ({
         action: x.action,
         parameters: x.parameters,

--- a/packages/nlg/src/action-manager.js
+++ b/packages/nlg/src/action-manager.js
@@ -96,7 +96,7 @@ class ActionManager extends Clonable {
   /**
    * Returns a processed answer after execute a list of given actions.
    * @param {String} intent Name of the intent.
-   * @param {String} input original answer data structure
+   * @param {String|Object} input original answer data structure
    */
   async processActions(intent, input) {
     const actionList = this.findActions(intent);

--- a/packages/nlg/src/action-manager.js
+++ b/packages/nlg/src/action-manager.js
@@ -61,7 +61,7 @@ class ActionManager extends Clonable {
    * Find the index of an action
    * @param {String} intent Name of the intent.
    * @param {String} action Name of the action.
-   * @param {String[]} list of parameters Parameters of the action.
+   * @param {String[]} parameters list of parameters of the action.
    */
   posAction(intent, action, parameters) {
     if (!this.actions[intent]) {
@@ -96,7 +96,7 @@ class ActionManager extends Clonable {
   /**
    * Returns a processed answer after execute a list of given actions.
    * @param {String} intent Name of the intent.
-   * @param {String} original answer
+   * @param {String} input original answer data structure
    */
   async processActions(intent, input) {
     const actionList = this.findActions(intent);
@@ -136,6 +136,7 @@ class ActionManager extends Clonable {
    * @param {String} intent Name of the intent.
    * @param {String} action Action to be executed
    * @param {String} parameters Parameters of the action
+   * @param {function} fn Function of the action
    */
   addAction(intent, action, parameters, fn) {
     if (this.posAction(intent, action, parameters) === -1) {

--- a/packages/nlg/src/nlg-manager.js
+++ b/packages/nlg/src/nlg-manager.js
@@ -124,15 +124,16 @@ class NlgManager extends Clonable {
         matchFound = false;
       }
     } while (matchFound);
+    if (srcText.answer) {
+      srcText.answer = text;
+    } else {
+      srcText = text;
+    }
     const template = this.container.get('Template');
     if (template && context) {
       return template.compile(srcText, context);
     }
-    if (srcText.answer) {
-      srcText.answer = text;
-      return srcText;
-    }
-    return text;
+    return srcText;
   }
 
   renderRandom(srcInput) {

--- a/packages/nlp/src/context-manager.js
+++ b/packages/nlp/src/context-manager.js
@@ -127,14 +127,14 @@ class ContextManager extends Clonable {
   }
 
   async resetConversations() {
-    Object.keys(this.contextDictionary).forEach(async (cid) => {
+    for (const cid of Object.keys(this.contextDictionary)) {
       await this.resetConversation(cid);
-    });
+    }
   }
 
   async resetConversation(cid) {
     const logger = this.container.get('logger');
-    logger.debug(`reseting context in conversation: ${cid}`);
+    logger.debug(`resetting context in conversation: ${cid}`);
     const conversationCtx = this.contextDictionary[cid];
     Object.keys(conversationCtx).forEach((convCtxKey) => {
       delete conversationCtx[convCtxKey];

--- a/packages/nlp/src/nlp.js
+++ b/packages/nlp/src/nlp.js
@@ -650,17 +650,15 @@ class Nlp extends Clonable {
         });
       }
       context.slotFill = output.slotFill;
-      if (output.srcAnswer) {
-        // Re-Render Answer to also replace newly added entities in srcAnswer
-        output.srcAnswer = this.nlgManager.renderText(
-          output.srcAnswer,
-          context
-        );
-      }
     }
     const answers = await this.nlgManager.run({ ...output });
     output.answers = answers.answers;
     output.answer = answers.answer;
+    if (output.srcAnswer) {
+      // Re-Render Answer to also replace newly added entities in srcAnswer
+      output.srcAnswer = this.nlgManager.renderText(output.srcAnswer, context);
+      output.answer = output.srcAnswer;
+    }
     output = await this.actionManager.run({ ...output });
     if (this.settings.calculateSentiment) {
       const sentiment = await this.getSentiment(locale, utterance);

--- a/packages/nlp/src/nlp.js
+++ b/packages/nlp/src/nlp.js
@@ -657,9 +657,14 @@ class Nlp extends Clonable {
     if (this.settings.executeActionsBeforeAnswers) {
       output = await this.actionManager.run({ ...output });
     }
-    const answers = await this.nlgManager.run({ ...output });
-    output.answers = answers.answers;
-    output.answer = answers.answer;
+    if (this.settings.executeActionsBeforeAnswers && output.answer) {
+      // Render answer from actions and use as final answer
+      output.answer = this.nlgManager.renderText(output.answer, context);
+    } else {
+      const answers = await this.nlgManager.run({ ...output });
+      output.answers = answers.answers;
+      output.answer = answers.answer;
+    }
     if (output.srcAnswer) {
       // Re-Render Answer to also replace newly added entities in srcAnswer
       output.srcAnswer = this.nlgManager.renderText(output.srcAnswer, context);

--- a/packages/nlp/src/nlp.js
+++ b/packages/nlp/src/nlp.js
@@ -590,12 +590,12 @@ class Nlp extends Clonable {
     let output = await this.nluManager.process(input);
     if (forceNER || !this.slotManager.isEmpty) {
       const optionalUtterance = await this.ner.generateEntityUtterance(
-        locale,
+        output.locale || locale,
         utterance
       );
       if (optionalUtterance && optionalUtterance !== utterance) {
         const optionalInput = {
-          locale,
+          locale: output.locale || locale,
           utterance: optionalUtterance,
           context,
           settings: this.applySettings(settings, this.settings.nlu),

--- a/packages/nlp/src/nlp.js
+++ b/packages/nlp/src/nlp.js
@@ -677,8 +677,7 @@ class Nlp extends Clonable {
     }
     if (output.srcAnswer) {
       // Re-Render Answer to also replace newly added entities in srcAnswer
-      output.srcAnswer = this.nlgManager.renderText(output.srcAnswer, context);
-      output.answer = output.srcAnswer;
+      output.answer = this.nlgManager.renderText(output.srcAnswer, context);
     }
     if (!this.settings.executeActionsBeforeAnswers) {
       output = await this.actionManager.run({ ...output });

--- a/packages/nlp/src/nlp.js
+++ b/packages/nlp/src/nlp.js
@@ -657,6 +657,12 @@ class Nlp extends Clonable {
         });
       }
       context.slotFill = output.slotFill;
+      if (output.srcAnswer) {
+        output.srcAnswer = this.nlgManager.renderText(
+          output.srcAnswer,
+          context
+        );
+      }
     }
     await this.contextManager.setContext(sourceInput, context);
     delete output.context;

--- a/packages/nlp/src/nlp.js
+++ b/packages/nlp/src/nlp.js
@@ -84,6 +84,7 @@ class Nlp extends Clonable {
         autoLoad: true,
         autoSave: true,
         modelFileName: 'model.nlp',
+        executeActionsBeforeAnswers: false,
       },
       false
     );

--- a/packages/nlp/src/nlp.js
+++ b/packages/nlp/src/nlp.js
@@ -125,6 +125,9 @@ class Nlp extends Clonable {
     if (this.settings.calculateSentiment === undefined) {
       this.settings.calculateSentiment = true;
     }
+    if (this.settings.executeActionsBeforeAnswers === undefined) {
+      this.settings.executeActionsBeforeAnswers = false;
+    }
   }
 
   async start() {
@@ -651,6 +654,9 @@ class Nlp extends Clonable {
       }
       context.slotFill = output.slotFill;
     }
+    if (this.settings.executeActionsBeforeAnswers) {
+      output = await this.actionManager.run({ ...output });
+    }
     const answers = await this.nlgManager.run({ ...output });
     output.answers = answers.answers;
     output.answer = answers.answer;
@@ -659,7 +665,9 @@ class Nlp extends Clonable {
       output.srcAnswer = this.nlgManager.renderText(output.srcAnswer, context);
       output.answer = output.srcAnswer;
     }
-    output = await this.actionManager.run({ ...output });
+    if (!this.settings.executeActionsBeforeAnswers) {
+      output = await this.actionManager.run({ ...output });
+    }
     if (this.settings.calculateSentiment) {
       const sentiment = await this.getSentiment(locale, utterance);
       output.sentiment = sentiment ? sentiment.sentiment : undefined;

--- a/packages/nlp/test/nlp.test.js
+++ b/packages/nlp/test/nlp.test.js
@@ -22,6 +22,7 @@
  */
 
 const { Nlp } = require('../src');
+const TemplateMock = require('./template-mock');
 
 const defaultCorpus = {
   name: 'corpus',
@@ -919,16 +920,6 @@ describe('NLP', () => {
         executeActionsBeforeAnswers: true,
       });
 
-      // needed for text rendering
-      class TemplateMock {
-        compile(str, context) {
-          if (str && str.answer && context.name) {
-            str.answer = str.answer.replace(/{{[ ]?name[ ]?}}/g, context.name);
-          }
-          return str;
-        }
-      }
-
       nlp.container.register('Template', TemplateMock, true);
       nlp.addDocument('en', 'Who am i?', 'who_am_i');
       nlp.addAnswer('en', 'who_am_i', 'You are {{ name }}');
@@ -954,16 +945,6 @@ describe('NLP', () => {
         autoSave: false,
         executeActionsBeforeAnswers: false,
       });
-
-      // needed for text rendering
-      class TemplateMock {
-        compile(str, context) {
-          if (str && str.answer && context.name) {
-            str.answer = str.answer.replace(/{{[ ]?name[ ]?}}/g, context.name);
-          }
-          return str;
-        }
-      }
 
       nlp.container.register('Template', TemplateMock, true);
       nlp.addDocument('en', 'Who am i?', 'who_am_i');

--- a/packages/nlp/test/nlp.test.js
+++ b/packages/nlp/test/nlp.test.js
@@ -818,8 +818,10 @@ describe('NLP', () => {
       });
       nlp.addDocument('en', 'Who am i?', 'who_am_i');
       nlp.addAnswer('en', 'who_am_i', 'You are HAL');
+      let actionCalled = false;
       nlp.addAction('who_am_i', 'testaction', ['param1'], (data, param1) => {
         expect(param1).toEqual('param1');
+        actionCalled = true;
         data.answer = 'answer';
         return data;
       });
@@ -832,6 +834,7 @@ describe('NLP', () => {
       expect(output.utterance).toEqual(input.utterance);
       expect(output.intent).toEqual('who_am_i');
       expect(output.answer).toEqual('answer');
+      expect(actionCalled).toEqual(true);
     });
     test('The action is executed after answer generation (default) and answer returned as string', async () => {
       const nlp = new Nlp({
@@ -840,8 +843,10 @@ describe('NLP', () => {
       });
       nlp.addDocument('en', 'Who am i?', 'who_am_i');
       nlp.addAnswer('en', 'who_am_i', 'You are HAL');
+      let actionCalled = false;
       nlp.addAction('who_am_i', 'testaction', ['param1'], (data, param1) => {
         expect(param1).toEqual('param1');
+        actionCalled = true;
         return 'answer';
       });
       await nlp.train();
@@ -853,8 +858,9 @@ describe('NLP', () => {
       expect(output.utterance).toEqual(input.utterance);
       expect(output.intent).toEqual('who_am_i');
       expect(output.answer).toEqual('answer');
+      expect(actionCalled).toEqual(true);
     });
-    test('The action is executed before answer generation (when configured that way) and answer is not overridden', async () => {
+    test('The action is executed before answer generation (when configured that way) and answer determined normally when no answer set', async () => {
       const nlp = new Nlp({
         languages: ['en'],
         autoSave: false,
@@ -862,7 +868,34 @@ describe('NLP', () => {
       });
       nlp.addDocument('en', 'Who am i?', 'who_am_i');
       nlp.addAnswer('en', 'who_am_i', 'You are HAL');
+      let actionCalled = false;
       nlp.addAction('who_am_i', 'testaction', ['param1'], (data, param1) => {
+        expect(param1).toEqual('param1');
+        actionCalled = true;
+        return data;
+      });
+      await nlp.train();
+      const input = {
+        locale: 'en',
+        utterance: 'Who am i?',
+      };
+      const output = await nlp.process(input);
+      expect(output.utterance).toEqual(input.utterance);
+      expect(output.intent).toEqual('who_am_i');
+      expect(output.answer).toEqual('You are HAL');
+      expect(actionCalled).toEqual(true);
+    });
+    test('The action is executed before answer generation (when configured that way) and answer set in action is used', async () => {
+      const nlp = new Nlp({
+        languages: ['en'],
+        autoSave: false,
+        executeActionsBeforeAnswers: true,
+      });
+      nlp.addDocument('en', 'Who am i?', 'who_am_i');
+      nlp.addAnswer('en', 'who_am_i', 'You are HAL');
+      let actionCalled = false;
+      nlp.addAction('who_am_i', 'testaction', ['param1'], (data, param1) => {
+        actionCalled = true;
         expect(param1).toEqual('param1');
         data.answer = 'answer';
         return data;
@@ -876,6 +909,7 @@ describe('NLP', () => {
       expect(output.utterance).toEqual(input.utterance);
       expect(output.intent).toEqual('who_am_i');
       expect(output.answer).toEqual('answer');
+      expect(actionCalled).toEqual(true);
     });
   });
 

--- a/packages/nlp/test/template-mock.js
+++ b/packages/nlp/test/template-mock.js
@@ -1,0 +1,13 @@
+/**
+ * Class that does minimal text replacement of a context property "name" used for some nlp tests
+ */
+class TemplateMock {
+  compile(str, context) {
+    if (str && str.answer && context.name) {
+      str.answer = str.answer.replace(/{{[ ]?name[ ]?}}/g, context.name);
+    }
+    return str;
+  }
+}
+
+module.exports = TemplateMock;

--- a/packages/nlp/test/template-mock.js
+++ b/packages/nlp/test/template-mock.js
@@ -4,7 +4,7 @@
 class TemplateMock {
   compile(str, context) {
     if (str && str.answer && context.name) {
-      str.answer = str.answer.replace(/{{[ ]?name[ ]?}}/g, context.name);
+      str.answer = str.answer.replace(/{{ ?name ?}}/g, context.name);
     }
     return str;
   }

--- a/packages/slot/src/slot-manager.js
+++ b/packages/slot/src/slot-manager.js
@@ -180,6 +180,20 @@ class SlotManager {
     });
   }
 
+  generateEntityAliases(entities) {
+    const aliases = [];
+    const dict = {};
+    for (let i = 0; i < entities.length; i += 1) {
+      const entity = entities[i];
+      if (!dict[entity.entity]) {
+        dict[entity.entity] = [];
+      }
+      aliases[i] = `${entity.entity}_${dict[entity.entity].length}`;
+      dict[entity.entity].push(true);
+    }
+    return aliases;
+  }
+
   process(srcResult, srcContext) {
     const result = srcResult;
     const context = srcContext;
@@ -203,9 +217,13 @@ class SlotManager {
       // No mandatory entities defined, we repeat the answer from last time
       return false;
     }
+    const aliases = this.generateEntityAliases(result.entities);
     for (let i = 0, l = result.entities.length; i < l; i += 1) {
+      const entity = result.entities[i];
+      console.log('handle entity', entity.option, entity.entity, aliases[i]);
       // Remove existing mandatory entities to see what's left
-      delete mandatorySlots[result.entities[i].entity];
+      delete mandatorySlots[entity.entity];
+      delete mandatorySlots[aliases[i]];
     }
     if (context.slotFill && mandatorySlots[context.slotFill.currentSlot]) {
       // Last time requested slot was not filled by current answer automatically,

--- a/packages/slot/src/slot-manager.js
+++ b/packages/slot/src/slot-manager.js
@@ -225,6 +225,8 @@ class SlotManager {
     }
     keys = Object.keys(mandatorySlots);
     if (!keys || keys.length === 0) {
+      // All mandatory slots are filled, so we are done. No further questions needed
+      delete result.srcAnswer;
       return true;
     }
     if (context.slotFill && context.slotFill.intent === result.intent) {

--- a/packages/slot/test/slot-manager.test.js
+++ b/packages/slot/test/slot-manager.test.js
@@ -346,7 +346,6 @@ describe('Slot Manager', () => {
         intent: 'intent',
         utterance: 'hello',
         answer: 'answer',
-        srcAnswer: 'srcAnswer',
         score: 1,
         entities: [
           {

--- a/packages/slot/test/slot-manager.test.js
+++ b/packages/slot/test/slot-manager.test.js
@@ -360,6 +360,64 @@ describe('Slot Manager', () => {
         ],
       });
     });
+    test('If slot fill is waiting for an entity and builtin parsed it, use the found builtin entity', () => {
+      const manager = new SlotManager();
+      manager.addSlot('intent', 'duration', true);
+      const result = {
+        intent: undefined,
+        utterance: 'For twenty minutes',
+        score: 1,
+        entities: [
+          {
+            start: 4,
+            end: 18,
+            len: 15,
+            accuracy: 0.95,
+            sourceText: 'twenty minutes',
+            utteranceText: 'twenty minutes',
+            entity: 'duration',
+            resolution: {
+              strValue: '1200',
+              value: 1200,
+              unit: 'second',
+            },
+          },
+        ],
+      };
+      const context = {
+        slotFill: {
+          currentSlot: 'duration',
+          intent: 'intent',
+          answer: 'answer',
+          srcAnswer: 'srcAnswer',
+          entities: [],
+        },
+      };
+      const actual = manager.process(result, context);
+      expect(actual).toBeTruthy();
+      expect(result).toEqual({
+        intent: 'intent',
+        utterance: 'For twenty minutes',
+        answer: 'answer',
+        score: 1,
+        entities: [
+          {
+            start: 4,
+            end: 18,
+            len: 15,
+            accuracy: 0.95,
+            sourceText: 'twenty minutes',
+            utteranceText: 'twenty minutes',
+            entity: 'duration',
+            resolution: {
+              strValue: '1200',
+              value: 1200,
+              unit: 'second',
+            },
+          },
+        ],
+      });
+    });
     test('If there are slots left, pick the next one', () => {
       const manager = new SlotManager();
       manager.addSlot('intent', 'entity1', true, { en: 'Enter entity1' });
@@ -413,6 +471,193 @@ describe('Slot Manager', () => {
               sourceText: 'hello',
               start: 0,
               utteranceText: 'hello',
+            },
+          ],
+          intent: 'intent',
+          localeIso2: 'en',
+          srcAnswer: 'srcAnswer',
+        },
+      });
+    });
+    test('If there are slots left, pick the next one, also with numbered entities', () => {
+      const manager = new SlotManager();
+      manager.addSlot('intent', 'entity1_0', true, { en: 'Enter entity1-0' });
+      manager.addSlot('intent', 'entity1_1', true, { en: 'Enter entity1-1' });
+      manager.addSlot('intent', 'entity2', true, { en: 'Enter entity2' });
+      const result = {
+        intent: undefined,
+        utterance: 'hello',
+        score: 1,
+        entities: [
+          {
+            entity: 'entity1',
+            utteranceText: 'entity1-0',
+            sourceText: 'entity1-0',
+            accuracy: 0.95,
+            start: 0,
+            end: 4,
+            len: 5,
+          },
+          {
+            entity: 'entity1',
+            utteranceText: 'entity1-1',
+            sourceText: 'entity1-1',
+            accuracy: 0.95,
+            start: 0,
+            end: 4,
+            len: 5,
+          },
+        ],
+      };
+      const context = {
+        slotFill: {
+          currentSlot: 'entity1_1',
+          intent: 'intent',
+          answer: 'answer',
+          srcAnswer: 'srcAnswer',
+          entities: [],
+          localeIso2: 'en',
+        },
+      };
+      const actual = manager.process(result, context);
+      expect(actual).toBeTruthy();
+      expect(result).toEqual({
+        intent: 'intent',
+        localeIso2: 'en',
+        utterance: 'hello',
+        answer: 'answer',
+        srcAnswer: 'Enter entity2',
+        score: 1,
+        entities: [
+          {
+            entity: 'entity1',
+            utteranceText: 'entity1-0',
+            sourceText: 'entity1-0',
+            accuracy: 0.95,
+            start: 0,
+            end: 4,
+            len: 5,
+          },
+          {
+            entity: 'entity1',
+            utteranceText: 'entity1-1',
+            sourceText: 'entity1-1',
+            accuracy: 0.95,
+            start: 0,
+            end: 4,
+            len: 5,
+          },
+        ],
+        slotFill: {
+          answer: 'answer',
+          currentSlot: 'entity2',
+          entities: [
+            {
+              entity: 'entity1',
+              utteranceText: 'entity1-0',
+              sourceText: 'entity1-0',
+              accuracy: 0.95,
+              start: 0,
+              end: 4,
+              len: 5,
+            },
+            {
+              entity: 'entity1',
+              utteranceText: 'entity1-1',
+              sourceText: 'entity1-1',
+              accuracy: 0.95,
+              start: 0,
+              end: 4,
+              len: 5,
+            },
+          ],
+          intent: 'intent',
+          localeIso2: 'en',
+          srcAnswer: 'srcAnswer',
+        },
+      });
+    });
+    test('If there are slots left, pick the next one, also with auto filling a numbered entity', () => {
+      const manager = new SlotManager();
+      manager.addSlot('intent', 'entity1_0', true, { en: 'Enter entity1-0' });
+      manager.addSlot('intent', 'entity1_1', true, { en: 'Enter entity1-1' });
+      manager.addSlot('intent', 'entity2', true, { en: 'Enter entity2' });
+      const result = {
+        intent: undefined,
+        utterance: 'hello',
+        score: 1,
+        entities: [
+          {
+            entity: 'entity1',
+            utteranceText: 'entity1-0',
+            sourceText: 'entity1-0',
+            accuracy: 0.95,
+            start: 0,
+            end: 4,
+            len: 5,
+          },
+        ],
+      };
+      const context = {
+        slotFill: {
+          currentSlot: 'entity1_1',
+          intent: 'intent',
+          answer: 'answer',
+          srcAnswer: 'srcAnswer',
+          entities: [],
+          localeIso2: 'en',
+        },
+      };
+      const actual = manager.process(result, context);
+      expect(actual).toBeTruthy();
+      expect(result).toEqual({
+        intent: 'intent',
+        localeIso2: 'en',
+        utterance: 'hello',
+        answer: 'answer',
+        srcAnswer: 'Enter entity2',
+        score: 1,
+        entities: [
+          {
+            entity: 'entity1',
+            utteranceText: 'entity1-0',
+            sourceText: 'entity1-0',
+            accuracy: 0.95,
+            start: 0,
+            end: 4,
+            len: 5,
+          },
+          {
+            entity: 'entity1_1',
+            utteranceText: 'hello',
+            sourceText: 'hello',
+            accuracy: 0.95,
+            start: 0,
+            end: 4,
+            len: 5,
+          },
+        ],
+        slotFill: {
+          answer: 'answer',
+          currentSlot: 'entity2',
+          entities: [
+            {
+              entity: 'entity1',
+              utteranceText: 'entity1-0',
+              sourceText: 'entity1-0',
+              accuracy: 0.95,
+              start: 0,
+              end: 4,
+              len: 5,
+            },
+            {
+              entity: 'entity1_1',
+              utteranceText: 'hello',
+              sourceText: 'hello',
+              accuracy: 0.95,
+              start: 0,
+              end: 4,
+              len: 5,
             },
           ],
           intent: 'intent',


### PR DESCRIPTION
# Pull Request Template

## PR Checklist

- [x] I have run `npm test` locally and all tests are passing.
- [x] I have added/updated tests for any new behavior.
- [x] If this is a significant change, an issue has already been created where the problem / solution was discussed: [N/A, or add link to issue here]

I currently can not intall the project because of issues reported with some used tarballs. WHen I execute the tests eslint reports 16 errors and 47 warnings all over the place. I can try to fix them, but So I decided to not add new tests. Please tell me if needed

## PR Description
While checking out slot Filling with v4 I encountered several unexpected topics I solve in this PR:
* When using slot filling there was a "srcAnswer" property added to the result, but this was not processed like the other answers by nlg. The PR adds that
* the nlg text rendering had an issue that when a contact was set that then "optional answer text" was not processed because done but ignored and original text was used. PR also addresses that
* The answers were rendered before the slot filling filled relevant entities. This PR adjust the order of actions to allow entities to be rendered correctly
* When a slot was requested the full uterance was always filled as entity - also if the entity was already parsed by buoltins or such. This lead to duplicated entries. This PR changes it so that the fallback "full utterance" is only added as entity if not filled already
* If a context contains a earlier srcAnswer property then this was repeated also if all mandatory entities were filled in the meantime. This PR removes the srcAnswer if all mandatory entities are filled.
* If slot filling is used the nlp code adds a special "entity utterance", but uses the initial locale parameter (whcih could be empty) to create this. This pot. leads to an empty locale used and then ner only uses the default builtins and not the configured builtins (e.g, Duckling). This PR uses a potentially already determinded locale.
* When slot filling generated an answer this was provided in srcAnwer additionally to pot. a normal "answer". DirectLineConnector as example is not sending back srcAnswer, so the question is not sent out. This PR changes the behaviour so that when the srcAnswer property is set this is also used as "answer", because it is "the better answer" :-)
* Actions are executed after the answers are rendered. With this actions can not modify the context to e.g. inkject new entities to be used in answer rendering. This PR adds a new nlp setting "executeActionsBeforeAnswers" to allow to execute the actions before answer rendering.
* Fix handling of numbered entities in slot filling and answer generation (added it here because else would have conflicted with PR #1164)

In fact it is a feature addition for handing slot filling answers by processing them like the other answers.

addresses #410, addresses #454, addresses #934, fixes #582, fixes #307

Additonally the commits are not "convenionally named". Sorry for that. Saw that too late and will change in future commits