### PR TITLE
fix: Discard Entity matches with a zero length

### DIFF
--- a/packages/ner/src/reduce-edges.js
+++ b/packages/ner/src/reduce-edges.js
@@ -80,6 +80,9 @@ function reduceEdges(edges, useMaxLength = true) {
   const edgeslen = edges.length;
   for (let i = 0; i < edgeslen; i += 1) {
     const edge = edges[i];
+    if (edge.len === 0) {
+      edge.discarded = true;
+    }
     if (!edge.discarded) {
       for (let j = i + 1; j < edgeslen; j += 1) {
         const other = edges[j];

--- a/packages/ner/test/extractor-trim.test.js
+++ b/packages/ner/test/extractor-trim.test.js
@@ -55,6 +55,76 @@ describe('Extractor Trim', () => {
       ]);
     });
 
+    test('It should not extract an empty entity', async () => {
+      const ner = new Ner();
+      ner.addBeforeFirstCondition('en', 'entity', 'profile');
+      ner.addAfterLastCondition('en', 'entity', 'of');
+      const input = {
+        text: 'profile of',
+        locale: 'en',
+      };
+      const actual = await ner.process(input);
+      expect(actual.entities).toEqual([]);
+    });
+
+    test('It should extract an entity when one trim rule matches', async () => {
+      const ner = new Ner();
+      ner.addBeforeFirstCondition('en', 'entity', 'profile');
+      ner.addAfterLastCondition('en', 'entity', 'of');
+      const input = {
+        text: 'profile of User',
+        locale: 'en',
+      };
+      const actual = await ner.process(input);
+      expect(actual.entities).toEqual([
+        {
+          accuracy: 0.99,
+          end: 14,
+          entity: 'entity',
+          len: 4,
+          sourceText: 'User',
+          start: 11,
+          subtype: 'afterLast',
+          type: 'trim',
+          utteranceText: 'User',
+        },
+      ]);
+    });
+    test('It should extract two entities when two trim rule matches', async () => {
+      const ner = new Ner();
+      ner.addBeforeFirstCondition('en', 'entity', 'profile');
+      ner.addAfterLastCondition('en', 'entity', 'of');
+      const input = {
+        text: 'First profile of User',
+        locale: 'en',
+      };
+      const actual = await ner.process(input);
+      expect(actual.entities).toEqual([
+        {
+          accuracy: 0.99,
+          end: 4,
+          entity: 'entity',
+          len: 5,
+          sourceText: 'First',
+          start: 0,
+          subtype: 'beforeFirst',
+          type: 'trim',
+          utteranceText: 'First',
+        },
+        {
+          accuracy: 0.99,
+          end: 20,
+          entity: 'entity',
+          len: 4,
+          sourceText: 'User',
+          start: 17,
+          subtype: 'afterLast',
+          type: 'trim',
+          utteranceText: 'User',
+        },
+      ]);
+    });
+
     test('It should extract a between rule finding simplest solution', async () => {
       const ner = new Ner();
       ner.addBetweenCondition('en', 'destination', ['to'], ['from']);
@@ -73,7 +143,7 @@ describe('Extractor Trim', () => {
           accuracy: 1,
           sourceText: 'travel to Madrid',
           utteranceText: 'travel to Madrid',
-          entity: 'destination'
+          entity: 'destination',
         },
       ]);
     });
@@ -96,7 +166,7 @@ describe('Extractor Trim', () => {
           accuracy: 1,
           sourceText: 'Madrid',
           utteranceText: 'Madrid',
-          entity: 'destination'
+          entity: 'destination',
         },
       ]);
     });


### PR DESCRIPTION
## PR Checklist

- [X] I have run `npm test` locally and all tests are passing.
- [X] I have added/updated tests for any new behavior.
- [X] If this is a significant change, an issue has already been created where the problem / solution was discussed: [N/A, or add link to issue here]

## PR Description

It can happen with Trim Entities that an empty string is matched. These "not valid" matches are discarded with the commit.
fixes #966
