### PR TITLE
fix: locale of import should have precedence over settings locale

### DIFF
--- a/packages/core/src/stemmer.js
+++ b/packages/core/src/stemmer.js
@@ -35,7 +35,7 @@ class Stemmer {
   getStemmer(srcInput) {
     const input = srcInput;
     const locale =
-      input.locale || input.settings ? input.settings.locale || 'en' : 'en';
+      input.locale || (input.settings ? input.settings.locale || 'en' : 'en');
     let stemmer = this.container.get(`stemmer-${locale}`);
     if (!stemmer) {
       const stemmerBert = this.container.get(`stemmer-bert`);


### PR DESCRIPTION
# Pull Request Template

## PR Checklist

- [x] I have run `npm test` locally and all tests are passing.
- [ ] I have added/updated tests for any new behavior.
- [ ] If this is a significant change, an issue has already been created where the problem / solution was discussed: [N/A, or add link to issue here]

## PR Description
Because of wrongly set brackets the "input.locale" was in fact never used as soon as also a settings locale was set -  and if nothing in settings it was falling back to "en".

This PR adjusts the brackets in the condition.

This was coming from a issue in the repository, but I do not know which anymore (sorry)

I decided to not adjust tests because it is obvious to mem that the brackets are wrong.