### PR TITLE
feat: use tokenizers to split words before doing entity detection

### DIFF
--- a/packages/ner/src/extractor-trim.js
+++ b/packages/ner/src/extractor-trim.js
@@ -62,6 +62,10 @@ class ExtractorTrim {
         let endIndex;
         if (condition && condition.options && condition.options.closest) {
           matchIndex = 1;
+          if (!match[matchIndex]) {
+            matchFound = false;
+            break;
+          }
           const leftWordIndex = match[0].indexOf(match[matchIndex]);
           startIndex = match.index - 1 + leftWordIndex;
           endIndex = startIndex + match[matchIndex].length - 1;
@@ -279,6 +283,11 @@ class ExtractorTrim {
     }
     const filteredResult = [];
     for (let i = 0; i < result.length; i += 1) {
+      // Remove common whitespace characters
+      result[i].sourceText = result[i].sourceText.replace(
+        /^[\s,.!?;:([\]'"¡¿)/]+|[\s,.!?;:([\]'"¡¿)/]+$/,
+        ''
+      );
       if (!this.mustSkip(result[i].utteranceText, condition)) {
         filteredResult.push(result[i]);
       }


### PR DESCRIPTION
# Pull Request Template

## PR Checklist

- [x] I have run `npm test` locally and all tests are passing.
- [x] I have added/updated tests for any new behavior.
- [x] If this is a significant change, an issue has already been created where the problem / solution was discussed: [N/A, or add link to issue here]

## PR Description
This PR is a fix for an issue reported in the repository (need to check if I can find it again). The problem is that the entity extraction was using normal whitespaces till now and this is not working in languages like japanese which is not using whitespaces.

So this PR introduce the usage of the tokenizer to splitup the text into words and then do the entity extraction based on this text. It also has the neded logic to correctly map the "positions" then back to the original text, so that the positions contained in the entity details are correct