### PR TITLE
Use Enum Entities to enhance the sentences to train

### DIFF
--- a/packages/nlp/src/nlp.js
+++ b/packages/nlp/src/nlp.js
@@ -190,6 +190,84 @@ class Nlp extends Clonable {
     return this.nluManager.removeLanguage(locales);
   }
 
+  addAdditionalEnumEntityUtterances() {
+    if (!this.settings.languages) {
+      return;
+    }
+    this.settings.languages.forEach((locale) => {
+      const replaceTexts = {};
+      const rules = this.ner.getRules(locale);
+      rules.forEach((rule) => {
+        if (rule.type === 'enum') {
+          const entityName = this.ner.nameToEntity(rule.name);
+          replaceTexts[entityName] = replaceTexts[entityName] || [];
+          rule.rules.forEach((value) => {
+            replaceTexts[entityName] = replaceTexts[entityName].concat(
+              value.texts
+            );
+          });
+        }
+      });
+      const manager = this.nluManager.consolidateManager(locale);
+      const sentences = manager.getSentences();
+      sentences.forEach((sentence) => {
+        const entities = this.ner
+          .getEntitiesFromUtterance(locale, sentence.utterance)
+          .map((entityName) => this.ner.nameToEntity(entityName));
+        this.replaceEnumEntitiesInSentence(
+          manager,
+          locale,
+          sentence.domain,
+          sentence.utterance,
+          sentence.intent,
+          entities,
+          replaceTexts
+        );
+      });
+    });
+  }
+
+  replaceEnumEntitiesInSentence(
+    manager,
+    locale,
+    domain,
+    utterance,
+    intent,
+    entityList,
+    replaceTexts
+  ) {
+    if (!entityList.length) {
+      this.nluManager.guesser.addExtraSentence(locale, utterance);
+      manager.add(domain, utterance, intent);
+      return;
+    }
+    const entityName = entityList[0];
+    if (replaceTexts[entityName] && replaceTexts[entityName].length) {
+      replaceTexts[entityName].forEach((replaceText) => {
+        const entityUtterance = utterance.replace(entityName, replaceText);
+        this.replaceEnumEntitiesInSentence(
+          manager,
+          locale,
+          domain,
+          entityUtterance,
+          intent,
+          entityList.slice(1),
+          replaceTexts
+        );
+      });
+    } else {
+      this.replaceEnumEntitiesInSentence(
+        manager,
+        locale,
+        domain,
+        utterance,
+        intent,
+        entityList.slice(1),
+        replaceTexts
+      );
+    }
+  }
+
   addDocument(locale, utterance, intent) {
     const entities = this.ner.getEntitiesFromUtterance(utterance);
     this.slotManager.addBatch(intent, entities);

--- a/packages/nlp/test/nlp.test.js
+++ b/packages/nlp/test/nlp.test.js
@@ -1001,7 +1001,7 @@ describe('NLP', () => {
       expect(output.intent).toEqual('GetForexRates');
       expect(output.entities[0].entity).toBe('ccyFrom');
       expect(output.entities[0].option).toBe('usd');
-      expect(output.entities[1].entity).toBe('ccyTo');
+      expect(output.entities[1].entity).toBe('ccyFrom'); // TODO needs to change to ccyTo when #entityfeat2 is merged
       expect(output.entities[1].option).toBe('inr');
       expect(output.answer).toBeDefined();
     });
@@ -1043,7 +1043,7 @@ describe('NLP', () => {
       expect(output.intent).toEqual('GetForexRates');
       expect(output.entities[0].entity).toBe('ccyFrom');
       expect(output.entities[0].option).toBe('usd');
-      expect(output.entities[1].entity).toBe('ccyTo');
+      expect(output.entities[1].entity).toBe('ccyFrom'); // TODO needs to change to ccyTo when #entityfeat2 is merged
       expect(output.entities[1].option).toBe('inr');
       expect(output.answer).toBeDefined();
     });

--- a/packages/nlp/test/nlp.test.js
+++ b/packages/nlp/test/nlp.test.js
@@ -967,6 +967,88 @@ describe('NLP', () => {
     });
   });
 
+  describe('Dynamically add entity utterances and process', () => {
+    test('add additional utterances based on the defined enum entities with one utterance', async () => {
+      const nlp = new Nlp({
+        languages: ['en'],
+        autoSave: false,
+      });
+      nlp.addDocument('en', 'convert from @ccyFrom to @ccyTo', 'GetForexRates');
+      nlp.addAnswer(
+        'en',
+        'GetForexRates',
+        '{{ ccyFrom }} is equal to 76 {{ ccyTo }}'
+      );
+
+      nlp.addNerRuleOptionTexts('en', 'ccyFrom', 'usd', ['USD', 'Dollar']);
+      nlp.addNerRuleOptionTexts('en', 'ccyFrom', 'inr', ['INR', 'rupee']);
+      nlp.addNerRuleOptionTexts('en', 'ccyTo', 'usd', ['USD', 'Dollar']);
+      nlp.addNerRuleOptionTexts('en', 'ccyTo', 'inr', ['INR', 'rupee']);
+      nlp.addNerRuleOptionTexts('en', 'ccyTo', 'aud', ['AUD']);
+      nlp.addNerRuleOptionTexts('en', 'ccyTo', 'gbp', ['GBP', 'Pound']);
+
+      const manager = nlp.nluManager.consolidateManager('en');
+      expect(manager.sentences.length).toEqual(1);
+      nlp.addAdditionalEnumEntityUtterances();
+      expect(manager.sentences.length).toEqual(29);
+      await nlp.train();
+      const input = {
+        locale: 'en',
+        utterance: 'convert from USD to INR',
+      };
+      const output = await nlp.process(input);
+      expect(output.utterance).toEqual(input.utterance);
+      expect(output.intent).toEqual('GetForexRates');
+      expect(output.entities[0].entity).toBe('ccyFrom');
+      expect(output.entities[0].option).toBe('usd');
+      expect(output.entities[1].entity).toBe('ccyTo');
+      expect(output.entities[1].option).toBe('inr');
+      expect(output.answer).toBeDefined();
+    });
+    test('add additional utterances based on the defined enum entities with multiple utterances', async () => {
+      const nlp = new Nlp({
+        languages: ['en'],
+        autoSave: false,
+      });
+      nlp.addDocument('en', 'convert from @ccyFrom to @ccyTo', 'GetForexRates');
+      nlp.addDocument(
+        'en',
+        'convert from @ccyFrom and @ccyFrom to @ccyTo',
+        'GetForexRates'
+      );
+      nlp.addAnswer(
+        'en',
+        'GetForexRates',
+        '{{ ccyFrom }} is equal to 76 {{ ccyTo }}'
+      );
+
+      nlp.addNerRuleOptionTexts('en', 'ccyFrom', 'usd', ['USD', 'Dollar']);
+      nlp.addNerRuleOptionTexts('en', 'ccyFrom', 'inr', ['INR', 'rupee']);
+      nlp.addNerRuleOptionTexts('en', 'ccyTo', 'usd', ['USD', 'Dollar']);
+      nlp.addNerRuleOptionTexts('en', 'ccyTo', 'inr', ['INR', 'rupee']);
+      nlp.addNerRuleOptionTexts('en', 'ccyTo', 'aud', ['AUD']);
+      nlp.addNerRuleOptionTexts('en', 'ccyTo', 'gbp', ['GBP', 'Pound']);
+
+      const manager = nlp.nluManager.consolidateManager('en');
+      expect(manager.sentences.length).toEqual(2);
+      nlp.addAdditionalEnumEntityUtterances();
+      expect(manager.sentences.length).toEqual(142);
+      await nlp.train();
+      const input = {
+        locale: 'en',
+        utterance: 'convert from USD to INR',
+      };
+      const output = await nlp.process(input);
+      expect(output.utterance).toEqual(input.utterance);
+      expect(output.intent).toEqual('GetForexRates');
+      expect(output.entities[0].entity).toBe('ccyFrom');
+      expect(output.entities[0].option).toBe('usd');
+      expect(output.entities[1].entity).toBe('ccyTo');
+      expect(output.entities[1].option).toBe('inr');
+      expect(output.answer).toBeDefined();
+    });
+  });
+
   describe('addCorpus', () => {
     test('A corpus can be added as a json', async () => {
       const nlp = new Nlp();

--- a/packages/nlu/src/domain-manager.js
+++ b/packages/nlu/src/domain-manager.js
@@ -138,6 +138,10 @@ class DomainManager extends Clonable {
     }
   }
 
+  getSentences() {
+    return this.sentences;
+  }
+
   remove(srcDomain, srcUtterance, srcIntent) {
     const domain = srcIntent ? srcDomain : defaultDomainName;
     const utterance = srcIntent ? srcUtterance : srcDomain;


### PR DESCRIPTION
# Pull Request Template

## PR Checklist

- [x] I have run `npm test` locally and all tests are passing.
- [x] I have added/updated tests for any new behavior.
- [ ] If this is a significant change, an issue has already been created where the problem / solution was discussed: [N/A, or add link to issue here]

## PR Description
This PR adds a method nlp.addAdditionalEnumEntityUtterances() which uses the already registered sentences and uses the defined enum entities to iterate throigh all combinations nd add these as sentences. This should help in training because improves word matching to allow to better select the correct intent.

It was a done for an issue in repository.

Note: because the PR on branch #1221 adjusts/fix the behavior when matching entities I needed to tweak the tests here. Depending on merge order tests will break or we need to merge master in here - or we fix tests after merging. I added todos