### PR TITLE
fix: correct the search logic for BertWordpieceTokenizer

### DIFF
--- a/packages/bert-tokenizer/test/bert-word-piece-tokenizer.test.js
+++ b/packages/bert-tokenizer/test/bert-word-piece-tokenizer.test.js
@@ -59,7 +59,7 @@ describe('BertWordPieceTokenizer', () => {
   describe('Get Best Affix', () => {
     test('Should calculate the best affix for a word', () => {
       const input = 'Supervised';
-      const expected = 'ised';
+      const expected = 'S';
       const tokenizer = new BertWordPieceTokenizer({ vocabContent: vocabEn });
       const actual = tokenizer.getBestAffix(input);
       expect(actual).toEqual(expected);
@@ -70,8 +70,8 @@ describe('BertWordPieceTokenizer', () => {
     test('Should return several tokens if word does not match and has affixes', () => {
       const input = 'Supervised';
       const expected = {
-        tokens: ['Super', '##v', '##ised'],
-        ids: [3198, 1964, 3673],
+        tokens: ['Super', '##vise', '##d'],
+        ids: [3198, 16641, 1181],
       };
       const tokenizer = new BertWordPieceTokenizer({ vocabContent: vocabEn });
       const actual = tokenizer.tokenizeWord(input);


### PR DESCRIPTION
# Pull Request Template

## PR Checklist

- [x] I have run `npm test` locally and all tests are passing.
- [x] I have added/updated tests for any new behavior.
- [ ] If this is a significant change, an issue has already been created where the problem / solution was discussed: [N/A, or add link to issue here]

## PR Description

fixes https://github.com/axa-group/nlp.js/issues/1192

I took he changes proposed in #1192, adjusted the tests to be successful and also added a test based on the description of the ticket (but honestly, @eric-lara @ericzon you need to state if the sematics of the issue is right ;-)) )

Credits go to @juancavallotti