### PR TITLE
fix: translations wrong link regex search

### DIFF
--- a/packages/bot/src/dialog-parse.js
+++ b/packages/bot/src/dialog-parse.js
@@ -60,7 +60,7 @@ const CARD_LINK_REGEX = /!?\[.{0,100}\]\(https?:\/\/.{0,2048}\)/gi;
 function trimLine(line) {
   const trimmedCondition = trimBetween(line.trim(), '[', ']', true);
   let trimmedSettings;
-  if (CARD_LINK_REGEX.test(line) || line.toLowerCase().startsWith('say ')) {
+  if (line.match(CARD_LINK_REGEX) || line.toLowerCase().startsWith('say ')) {
     trimmedSettings = {
       line,
       trimmed: '',


### PR DESCRIPTION
# Pull Request Template

## PR Checklist

- [x] I have run `npm test` locally and all tests are passing.
- [ ] I have added/updated tests for any new behavior.
- [ ] If this is a significant change, an issue has already been created where the problem / solution was discussed: [N/A, or add link to issue here]

## PR Description

Replace regex test command for string match to fix an issue with global regex flag. 

Quoting [mdm documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/test) about this topic:

```As with exec() (or in combination with it), test() called multiple times on the same global regular expression instance will advance past the previous match.```

This stateful behaviour generates an error when using the same regex for testing multiple lines.