### PR TITLE
test: parsing consecutive translations with links with regex

### DIFF
--- a/packages/bot/test/dialog-parse.test.js
+++ b/packages/bot/test/dialog-parse.test.js
@@ -66,7 +66,7 @@ describe('Dialog Parse', () => {
       ]);
     });
 
-    test('parse dialog with link', async () => {
+    test('parse dialog with link', () => {
       const dialog = `say Hello! this is a dialog with [link](http://www.test.com)`;
       const parsed = dialogParse(dialog);
       expect(parsed).toMatchObject([
@@ -79,6 +79,26 @@ describe('Dialog Parse', () => {
           type: 'say',
         },
       ]);
+    });
+
+    test('parse consecutive translastions with links, same regex object', () => {
+      const dialog = `-en This is my link [link](http://www.test.com) \n
+        -es Este es mi enlace [enlace](http://www.test.com)`;
+      const [parsed, secondParsed] = dialogParse(dialog);
+      expect(parsed).toMatchObject({
+        condition: '',
+        line: 'This is my link [link](http://www.test.com)',
+        settings: '',
+        srcLine: '-en This is my link [link](http://www.test.com)',
+        type: '-en',
+      });
+      expect(secondParsed).toMatchObject({
+        condition: '',
+        line: 'Este es mi enlace [enlace](http://www.test.com)',
+        settings: '',
+        srcLine: '-es Este es mi enlace [enlace](http://www.test.com)',
+        type: '-es',
+      });
     });
   });
 


### PR DESCRIPTION
# Pull Request Template

## PR Checklist

- [x] I have run `npm test` locally and all tests are passing.
- [x] I have added/updated tests for any new behavior.
- [ ] If this is a significant change, an issue has already been created where the problem / solution was discussed: [N/A, or add link to issue here]

## PR Description

Unit testing for #1238. 

Testing several translations with links in the same text. Regex should not be affected by previous parsing.