### PR TITLE
Update extractor-trim.js

### DIFF
--- a/packages/ner/src/extractor-trim.js
+++ b/packages/ner/src/extractor-trim.js
@@ -54,6 +54,13 @@ class ExtractorTrim {
   matchBetween(utterance, condition, name) {
     const result = [];
     let matchFound;
+    if(typeof condition.regex === 'string') {
+      if(condition.regex.startsWith('/'))
+        condition.regex = condition.regex.slice(1);
+      var regexArr = condition.regex.split('/');
+      var flag = regexArr.splice(-1);
+      condition.regex = new RegExp(regexArr.join('/'), flag);
+    }
     do {
       const match = condition.regex.exec(` ${utterance} `);
       if (match) {

--- a/packages/ner/src/extractor-trim.js
+++ b/packages/ner/src/extractor-trim.js
@@ -55,7 +55,7 @@ class ExtractorTrim {
     const result = [];
     let matchFound;
     if (typeof condition.regex === 'string') {
-      if(condition.regex.startsWith('/'))
+      if (condition.regex.startsWith('/'))
         condition.regex = condition.regex.slice(1);
       var regexArr = condition.regex.split('/');
       var flag = regexArr.splice(-1);

--- a/packages/ner/src/extractor-trim.js
+++ b/packages/ner/src/extractor-trim.js
@@ -54,7 +54,7 @@ class ExtractorTrim {
   matchBetween(utterance, condition, name) {
     const result = [];
     let matchFound;
-    if(typeof condition.regex === 'string') {
+    if (typeof condition.regex === 'string') {
       if(condition.regex.startsWith('/'))
         condition.regex = condition.regex.slice(1);
       var regexArr = condition.regex.split('/');


### PR DESCRIPTION
fix for error: exec is not a function

# Pull Request

## PR Checklist

- [✓] I have run `npm test` locally and all tests are passing.
- [✓] [(https://github.com/axa-group/nlp.js/issues/463)]

## PR Description

#463
In production if someone tries to load model nlp/json file instead of trainning from corpus, the match between function in extractor-trim.js under @nlpjs/ner package throws error: `TypeError: condition.regex.exec is not a function`  
The reason of this error is when saved in a json file the generated regex is saved as a string instead of regex data type.

FIX:  
- check if `condition.regex` is a string  
- modify the string to be used in `RegExp` function so it doesn't escape characters unneccesserily  
- convert `condition.regex` to regex  
- in training mode if `condition.regex` is already regex, the program executes as it should normally