### PR TITLE
fix: ner-matchBetween:bug

### DIFF
--- a/packages/ner/src/extractor-trim.js
+++ b/packages/ner/src/extractor-trim.js
@@ -55,7 +55,7 @@ class ExtractorTrim {
     const result = [];
     let matchFound;
     do {
-      const match = condition.regex.exec(` ${utterance} `);
+      const match = eval(condition.regex || '').exec(` ${utterance} `);
       if (match) {
         let matchIndex;
         let startIndex;


### PR DESCRIPTION
# Pull Request Template

## PR Checklist

- [ ] I have run `npm test` locally and all tests are passing.
- [ ] I have added/updated tests for any new behavior.
- [ ] If this is a significant change, an issue has already been created where the problem / solution was discussed: [N/A, or add link to issue here]

## PR Description

If we use a locally built nlp file, the regex parameter cannot use the exec method because it is in the form of a string
![image](https://user-images.githubusercontent.com/53501419/225843385-20800ddd-131d-44f1-b8d4-8aba66916428.png)
![image](https://user-images.githubusercontent.com/53501419/225843563-c6dc9679-a673-4efd-bc85-ad42bc994241.png)
