### PR TITLE
fix(ner): deserialize regex from JSON

### DIFF
--- a/packages/ner/src/ner.js
+++ b/packages/ner/src/ner.js
@@ -520,10 +520,14 @@ class Ner extends Clonable {
         json.rules[rKey][eKey].rules =
           json.rules[rKey][eKey].type === 'regex'
             ? json.rules[rKey][eKey].rules.map((rule) => Ner.str2regex(rule))
-            : json.rules[rKey][eKey].rules.map((rule) => ({
-                ...rule,
-                regex: Ner.str2regex(rule.regex),
-              }));
+            : json.rules[rKey][eKey].rules.map((rule) =>
+                typeof rule.regex === 'string'
+                  ? {
+                      ...rule,
+                      regex: Ner.str2regex(rule.regex),
+                    }
+                  : rule
+              );
       });
     });
 

--- a/packages/ner/src/ner.js
+++ b/packages/ner/src/ner.js
@@ -517,11 +517,13 @@ class Ner extends Clonable {
       const entityKeys = Object.keys(json.rules[rKey]);
 
       entityKeys.forEach((eKey) => {
-        if (json.rules[rKey][eKey].type === 'regex') {
-          json.rules[rKey][eKey].rules = json.rules[rKey][eKey].rules.map(
-            (rule) => Ner.str2regex(rule)
-          );
-        }
+        json.rules[rKey][eKey].rules =
+          json.rules[rKey][eKey].type === 'regex'
+            ? json.rules[rKey][eKey].rules.map((rule) => Ner.str2regex(rule))
+            : json.rules[rKey][eKey].rules.map((rule) => ({
+                ...rule,
+                regex: Ner.str2regex(rule.regex),
+              }));
       });
     });
 

--- a/packages/ner/test/ner.test.js
+++ b/packages/ner/test/ner.test.js
@@ -485,4 +485,29 @@ describe('NER', () => {
       ]);
     });
   });
+  describe('To & from JSON', () => {
+    test('It deserializes regular expressions', () => {
+      const instance = new Ner({ container });
+      instance.addBetweenCondition('en', 'test', 'from', 'to');
+      const json = JSON.stringify(instance.toJSON());
+      const instance2 = new Ner({ container });
+      instance2.fromJSON(JSON.parse(json));
+      const actual = instance2.getRules('en');
+      expect(actual).toEqual([
+        {
+          name: 'test',
+          rules: [
+            {
+              type: 'between',
+              leftWords: ['from'],
+              rightWords: ['to'],
+              regex: /(?<= from )(.*)(?= to )/gi,
+              options: {},
+            },
+          ],
+          type: 'trim',
+        },
+      ]);
+    });
+  });
 });


### PR DESCRIPTION
# Pull Request Template

## PR Checklist

- [x] I have run `npm test` locally and all tests are passing.

Some ESLint warnings, but same amount as in `master`:
<img width="287" alt="Screenshot 2023-05-18 at 11 25 50 PM" src="https://github.com/axa-group/nlp.js/assets/615381/714b0fee-1dd9-4fdb-b003-f28a64ad82bd">

All tests pass:
<img width="293" alt="Screenshot 2023-05-18 at 11 25 41 PM" src="https://github.com/axa-group/nlp.js/assets/615381/65f7895e-1b1a-4f67-ac62-cf092ad2a496">

- [x] I have added/updated tests for any new behavior.
- [x] If this is a significant change, an issue has already been created where the problem / solution was discussed: [N/A, or add link to issue here]

## PR Description

<!-- Describe Your PR Here! -->

Fixes a bug with Named Entity Recognition where it doesn't deserialize regular expressions from JSON properly for all rule types.

A possible alternative to the fixes in https://github.com/axa-group/nlp.js/pull/1292 and https://github.com/axa-group/nlp.js/pull/1278 (though I'm not 100% sure if it covers those use cases).