### PR TITLE
fix: Disable logging by default in nlu to fix 'Epoch' log message

### DIFF
--- a/packages/nlu/src/nlu.js
+++ b/packages/nlu/src/nlu.js
@@ -61,7 +61,7 @@ class Nlu extends Clonable {
         spellCheck: false,
         spellCheckDistance: 1,
         filterZeros: true,
-        log: true,
+        log: false,
       },
       false
     );


### PR DESCRIPTION
# Pull Request Template

Thanks for nlp.js. There is an issue in that it logs these messages:
```
Epoch 513 loss 0.004655355635269023 time 0ms
```

## PR Checklist

- [X] I have run `npm test` locally and all tests are passing.
- [ ] I have added/updated tests for any new behavior.
- [ ] If this is a significant change, an issue has already been created where the problem / solution was discussed: [N/A, or add link to issue here]

## PR Description

The nlu was configured to log by default. I am pretty sure that it cannot be disabled programmatically because there are [no settings](https://github.com/axa-group/nlp.js/blob/be04a67e44e8d22562a22dea4fed97031c8cf50d/packages/nlp/src/nlp.js#L628) passed into it from the nlu. It is also _extremely_ annoying to have these log messages output by default. All I did was disable it, but imo, it should probably be using the configured logger, instead of a `console.log`. I'd also expect that maybe _some_ settings should be passed into the `train()`.